### PR TITLE
Release: slate v2.1.10

### DIFF
--- a/html-templates/includes/site.header-bottom.tpl
+++ b/html-templates/includes/site.header-bottom.tpl
@@ -3,11 +3,12 @@
 {* TODO: replace with VFS-based contentBlocks engine *}
 
 {$heroNode = Site::resolvePath('content-blocks/about/short.md')}
+{$heroMarkdown = $heroNode->RealPath|file_get_contents|trim}
 
-{if $heroNode}
+{if $heroMarkdown}
     <div class="inner hero-ct">
         <div class="hero-text">
-    	   {$heroNode->RealPath|file_get_contents|markdown}
+    	   {$heroMarkdown|markdown}
         </div>
     </div>
 {/if}

--- a/site-root/sass/slate/_common.scss
+++ b/site-root/sass/slate/_common.scss
@@ -32,14 +32,16 @@ body {
     -webkit-font-smoothing: subpixel-antialiased;
 }
 
-.site.header {
-    background-image: image-url('header.jpg');
-    background-size: cover;
-    background-position: top;
-    position: relative;
+@if $hero-header-image {
+    .site.header {
+        background-image: image-url('header.jpg');
+        background-size: cover;
+        background-position: top;
+        position: relative;
 
-    &.reveal-hero {
-        height: 560px;
+        &.reveal-hero {
+            height: 560px;
+        }
     }
 }
 
@@ -84,29 +86,29 @@ body {
     &.has-image {
         background-color: #444;
         border-top: 2px solid #444;
-        
+
         .footer-info {
             background: rgba(white, .9);
             float: right;
             padding: 2em 1.5em;
             width: 250px;
         }
-    
+
         > .inner {
             background-position: center;
             background-repeat: no-repeat;
             background-size: cover;
             padding: 0;
         }
-    
+
         address {
             display: inline-block;
         }
-    
+
         small {
             clear: both;
             display: block;
             margin: 1em 0 0;
-        }        
+        }
     }
 }

--- a/site-root/sass/slate/_variables.scss
+++ b/site-root/sass/slate/_variables.scss
@@ -13,6 +13,8 @@ $heading-font:  Sanchez, Lato, Rockwell, 'Rockwell Std', Georgia, serif !default
 
 $omnibar-height: 2.75em;
 
+$hero-header-image: image-url('header.jpg') !default;
+
 // button colors
 $button-color:      mix(#dfdfdf, $accent-color, 95%) !default;
 $destructive-color: #ff332e !default;


### PR DESCRIPTION
- Suppress hero text container if `content-blocks/about/short.md` is empty
- Add `$hero-header-image` SASS variable for changing site header image or setting to `false` to disable