### PR TITLE
Omnibar tweaks

### DIFF
--- a/html-templates/app/slate-ext.tpl
+++ b/html-templates/app/slate-ext.tpl
@@ -10,5 +10,5 @@
 {/block}
 
 {block body}
-    {include includes/site.user-tools.tpl}
+    {include includes/site.user-tools.tpl fluid=true}
 {/block}

--- a/html-templates/includes/site.user-tools.tpl
+++ b/html-templates/includes/site.user-tools.tpl
@@ -1,5 +1,5 @@
 <div class="slate-omnibar site">
-    <div class="inner">
+    <div class="inner {if $fluid}fluid-width{/if}">
         <ul class="omnibar-items">
             {if $.User}
             <li class="omnibar-item">
@@ -61,7 +61,7 @@
                         {/if}
                         {$link.shortLabel|default:$link.label|escape}
                     </{tif $link.href ? a : span}>
-                    
+
                     {if $link.children}
                         <div class="omnibar-menu-ct">
                             <ul class="omnibar-menu">

--- a/site-root/sass/slate/modules/_omnibar.scss
+++ b/site-root/sass/slate/modules/_omnibar.scss
@@ -47,7 +47,10 @@
     top: 0;
     z-index: 99;
 
-    a {
+    a,
+    a:hover,
+    a:active,
+    a:visited {
         color: white;
         text-decoration: none;
     }

--- a/site-root/sass/slate/modules/_omnibar.scss
+++ b/site-root/sass/slate/modules/_omnibar.scss
@@ -45,7 +45,7 @@
     position: fixed;
     right: 0;
     top: 0;
-    z-index: 2;
+    z-index: 99;
 
     a {
         color: white;


### PR DESCRIPTION
1. Add support for a fluid-width omnibar
2. Use fluid-width omnibar for slate-ext apps
3. Bump omnibar z-index to 99 to prevent issues such as https://jarvus.atlassian.net/browse/CBL-206
4. Add link pseudo selectors to prevent recolored links in omnibar