### PR TITLE
Release: slate v2.1.23

### DIFF
--- a/html-templates/connectors/syncronizeComplete.email.tpl
+++ b/html-templates/connectors/syncronizeComplete.email.tpl
@@ -19,7 +19,7 @@
 
         <h2>Log</h2>
         <div class="sync-log">
-        {foreach item=entry from=$Job->log}
+        {foreach item=entry from=$Job->logEntries}
             {if $entry.level != 'debug'}
                 <div class="log-entry">
                     <div>{$entry.message|escape}</div>

--- a/html-templates/connectors/syncronizeComplete.email.tpl
+++ b/html-templates/connectors/syncronizeComplete.email.tpl
@@ -24,9 +24,10 @@
                 <div class="log-entry">
                     <div>{\Emergence\Logger::interpolate($entry.message, $entry.context)|escape}</div>
 
-                    {if $entry.changes}
+                    {$changes = default($entry.changes, $entry.context.changes)}
+                    {if $changes}
                         <dl>
-                            {foreach item=delta key=field from=$entry.changes}
+                            {foreach item=delta key=field from=$changes}
                                 <dt>{$field}</dt>
                                 <dd>{$delta.from|escape} -> {$delta.to|escape}</dd>
                             {/foreach}

--- a/html-templates/connectors/syncronizeComplete.email.tpl
+++ b/html-templates/connectors/syncronizeComplete.email.tpl
@@ -22,7 +22,7 @@
         {foreach item=entry from=$Job->logEntries}
             {if $entry.level != 'debug'}
                 <div class="log-entry">
-                    <div>{$entry.message|escape}</div>
+                    <div>{\Emergence\Logger::interpolate($entry.message, $entry.context)|escape}</div>
 
                     {if $entry.changes}
                         <dl>

--- a/html-templates/connectors/syncronizeComplete.tpl
+++ b/html-templates/connectors/syncronizeComplete.tpl
@@ -43,7 +43,7 @@
     <h2>Log</h2>
     <label><input type="checkbox" onchange="Ext.getBody().down('.sync-log').toggleCls('show-debug', this.checked)">Show debug entries</label>
     <section class="sync-log">
-    {foreach item=entry from=$Job->log}
+    {foreach item=entry from=$Job->logEntries}
         <article class="level-{$entry.level}">
             <div>{$entry.message|escape}</div>
 

--- a/html-templates/connectors/syncronizeComplete.tpl
+++ b/html-templates/connectors/syncronizeComplete.tpl
@@ -45,7 +45,7 @@
     <section class="sync-log">
     {foreach item=entry from=$Job->logEntries}
         <article class="level-{$entry.level}">
-            <div>{$entry.message|escape}</div>
+            <div>{\Emergence\Logger::interpolate($entry.message, $entry.context)|escape}</div>
 
             {if $entry.changes}
                 <dl>

--- a/html-templates/connectors/syncronizeComplete.tpl
+++ b/html-templates/connectors/syncronizeComplete.tpl
@@ -47,9 +47,10 @@
         <article class="level-{$entry.level}">
             <div>{\Emergence\Logger::interpolate($entry.message, $entry.context)|escape}</div>
 
-            {if $entry.changes}
+            {$changes = default($entry.changes, $entry.context.changes)}
+            {if $changes}
                 <dl>
-                    {foreach item=delta key=field from=$entry.changes}
+                    {foreach item=delta key=field from=$changes}
                         <dt>{$field}</dt>
                         <dd>{$delta.from|escape} -> {$delta.to|escape}</dd>
                     {/foreach}

--- a/php-classes/Slate/Progress/SectionInterimReportsRequestHandler.php
+++ b/php-classes/Slate/Progress/SectionInterimReportsRequestHandler.php
@@ -102,7 +102,7 @@ class SectionInterimReportsRequestHandler extends \RecordsRequestHandler
                 $recipients = [];
 
                 foreach ($email['reports'] AS $reportId) {
-                    $Report = SectionTermReport::getByID($reportId);
+                    $Report = SectionInterimReport::getByID($reportId);
 
                     if ($Report->Status == 'published') {
                         $reports[] = $Report;


### PR DESCRIPTION
- Fix synchronization log display on results page and email report.
    - Interpolate log messages
    - Add support for changes within 'context' array
- Fix issue with interim report emails querying term reports