### PR TITLE
Release: slate v2.1.25

### DIFF
--- a/php-config/Slate/DashboardRequestHandler.config.d/550_canvas.php
+++ b/php-config/Slate/DashboardRequestHandler.config.d/550_canvas.php
@@ -1,3 +1,0 @@
-<?php
-
-Slate\DashboardRequestHandler::$sources[] = Slate\UI\Adapters\Canvas::class;

--- a/php-config/Slate/UI/Omnibar.config.d/550_canvas.php
+++ b/php-config/Slate/UI/Omnibar.config.d/550_canvas.php
@@ -1,3 +1,0 @@
-<?php
-
-Slate\UI\Omnibar::$sources[] = Slate\UI\Adapters\Canvas::class;


### PR DESCRIPTION
- Remove canvas adapter configs migrated to slate-connector-canvas