### PR TITLE
Release: slate v2.2.20

### DIFF
--- a/html-templates/designs/site.tpl
+++ b/html-templates/designs/site.tpl
@@ -13,7 +13,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1"> {* responsive viewport *}
     {/block}
 
-    <title>{block "title"}{Site::getConfig(label)}{/block}</title>
+    <title>{block "title"}{$.Site.title|escape}{/block}</title>
 
     {block "css"}
         {include includes/site.css.tpl}

--- a/html-templates/people/person.tpl
+++ b/html-templates/people/person.tpl
@@ -35,18 +35,15 @@
                 </footer>
             </div>
         </div>
-        
+
         <div class="sidebar-col">
             <div class="col-inner">
-
-                {$Person = $data}
-            
                 {if $Person->PrimaryPhoto}
                 <div class="sidebar-item">
                     <a href="{$Person->PrimaryPhoto->WebPath}" class="display-photo-link"><img class="display-photo" src="{$Person->PrimaryPhoto->getThumbnailRequest(646,646)}" alt="Profile Photo: {$Person->FullName|escape}" style="max-width:100%;height:auto" width=323 height=323 /></a>
                 </div>
                 {/if}
-            
+
                 <div class="sidebar-item">
                 {if $Person->Biography}
                     <div class="well about-bio">
@@ -60,36 +57,66 @@
                     </div>
                 {/if}
                 </div>
-            
+
                 {if $.Session->hasAccountLevel('Staff')}
-                <div class="sidebar-item">
-                    <div class="well profile-contact-info">
-                        <h4 class="well-title">Contact Info <small class="muted">(Staff-Only)</small></h4>
-                        <dl class="kv-list">
-                            {if $Person->Email}
-                                <div class="dli">
-                                    <dt>Email</dt>
-                                    <dd><a href="mailto:{$Person->Email}" title="Email {$Person->FullName|escape}">{$Person->Email}</a></dd>
-                                </div>
-                            {/if}
-                
-                            {if $Person->Phone}
-                                <div class="dli">
-                                    <dt>Phone</dt>
-                                    <!-- tel: URL scheme fails in desktop browsers -->
-                                    <dd><!-- <a href="tel:{$Person->Phone}"> -->{$Person->Phone|phone}<!-- </a> --></dd>
-                                </div>
-                            {/if}
- 
-                             {foreach $Person->Relationships Relationship}
-                                <div class="dli">
-                                    <dt>{$Relationship->Label}</dt>
-                                    <dd>{personLink $Relationship->RelatedPerson photo=no}</dd>
-                                </div>
-                            {/foreach}
-                        </dl>
+                    <div class="sidebar-item">
+                        <div class="well profile-contact-info">
+                            <h4 class="well-title">Contact Info <small class="muted">(Staff-Only)</small></h4>
+                            <dl class="kv-list">
+                                {if $Person->Email}
+                                    <div class="dli">
+                                        <dt>Email</dt>
+                                        <dd><a href="mailto:{$Person->Email}" title="Email {$Person->FullName|escape}">{$Person->Email}</a></dd>
+                                    </div>
+                                {/if}
+
+                                {if $Person->Phone}
+                                    <div class="dli">
+                                        <dt>Phone</dt>
+                                        <!-- tel: URL scheme fails in desktop browsers -->
+                                        <dd><!-- <a href="tel:{$Person->Phone}"> -->{$Person->Phone|phone}<!-- </a> --></dd>
+                                    </div>
+                                {/if}
+
+                                {foreach $Person->Relationships Relationship}
+                                    <div class="dli">
+                                        <dt>{$Relationship->Label}</dt>
+                                        <dd>{personLink $Relationship->RelatedPerson photo=no}</dd>
+                                    </div>
+                                {/foreach}
+                            </dl>
+                        </div>
                     </div>
-                </div>
+                {/if}
+
+                {template linksEntry entry}
+                    {if $entry.href}<a href="{$entry.href|escape}">{/if}
+                        {$entry.label|escape}
+                    {if $entry.href}</a>{/if}
+                {/template}
+
+                {foreach item=linkGroup from=Slate\UI\UserProfile::getLinks($Person)}
+                    <div class="sidebar-item">
+                        <div class="well profile-contact-info">
+                            <h4 class="well-title">{linksEntry $linkGroup}</h4>
+
+                            <dl class="kv-list">
+                                {foreach item=link from=$linkGroup.children}
+                                    {if $link.children}
+                                        <div class="dli">
+                                            <dt>{linksEntry $link}</dt>
+                                            {foreach item=subLink from=$link.children}
+                                                <dd>{linksEntry $subLink}</dd>
+                                            {/foreach}
+                                        </div>
+                                    {else}
+                                        <dd>{linksEntry $link}</dd>
+                                    {/if}
+                                {/foreach}
+                            </dl>
+                        </div>
+                    </div>
+                {/foreach}
             </div>
         </div>
     </div>

--- a/html-templates/people/person.tpl
+++ b/html-templates/people/person.tpl
@@ -47,12 +47,12 @@
                 <div class="sidebar-item">
                 {if $Person->Biography}
                     <div class="well about-bio">
-                        <h4 class="well-title">Bio</h4>
+                        <h3 class="well-title">Bio</h3>
                         {$Person->Biography|escape|markdown}
                     </div>
                 {elseif $Person->About}
                     <div class="well about-bio">
-                        <h4 class="well-title">About Me</h4>
+                        <h3 class="well-title">About Me</h3>
                         {$Person->About|escape|markdown}
                     </div>
                 {/if}
@@ -61,7 +61,7 @@
                 {if $.Session->hasAccountLevel('Staff')}
                     <div class="sidebar-item">
                         <div class="well profile-contact-info">
-                            <h4 class="well-title">Contact Info <small class="muted">(Staff-Only)</small></h4>
+                            <h3 class="well-title">Contact Info <small class="muted">(Staff-Only)</small></h3>
                             <dl class="kv-list">
                                 {if $Person->Email}
                                     <div class="dli">
@@ -98,7 +98,7 @@
                 {foreach item=linkGroup from=Slate\UI\UserProfile::getLinks($Person)}
                     <div class="sidebar-item">
                         <div class="well profile-contact-info">
-                            <h4 class="well-title">{linksEntry $linkGroup}</h4>
+                            <h3 class="well-title">{linksEntry $linkGroup}</h3>
 
                             <dl class="kv-list">
                                 {foreach item=link from=$linkGroup.children}

--- a/html-templates/sections/courseSection.tpl
+++ b/html-templates/sections/courseSection.tpl
@@ -128,23 +128,34 @@
                     </dl>
                 </section>
 
+                {template linksEntry entry}
+                    {if $entry.href}<a href="{$entry.href|escape}">{/if}
+                        {$entry.label|escape}
+                    {if $entry.href}</a>{/if}
+                {/template}
 
-                {$launchers = $Section->getLaunchers()}
-                {if count($launchers)}
-                    <h3>Other Websites</h3>
-                    {foreach from=$launchers item=launcher}
-                        <a class="button" href="{$launcher.url|escape}" target="_blank">{$launcher.title|escape}</a>
-                    {/foreach}
-                {/if}
+                {foreach item=linkGroup from=Slate\UI\SectionProfile::getLinks($Section)}
+                    <div class="sidebar-item">
+                        <div class="well profile-contact-info">
+                            <h3 class="well-title">{linksEntry $linkGroup}</h3>
 
-
-                {if $.User->hasAccountLevel(Staff)}
-                    <h3>Course Tools</h3>
-                    <ul class="course-section-tools plain">
-                        <li class="copy-email"><a class="button" href="#copy-section-emails">Copy Email List</a></li>
-                        <li class="download-roster"><a class="button" href="{$Section->getURL()}/students?format=csv&columns=LastName,FirstName,Gender,Username,PrimaryEmail,PrimaryPhone,StudentNumber,Advisor,GraduationYear">Download Roster</a></li>
-                    </ul>
-                {/if}
+                            <dl class="kv-list">
+                                {foreach item=link from=$linkGroup.children}
+                                    {if $link.children}
+                                        <div class="dli">
+                                            <dt>{linksEntry $link}</dt>
+                                            {foreach item=subLink from=$link.children}
+                                                <dd>{linksEntry $subLink}</dd>
+                                            {/foreach}
+                                        </div>
+                                    {else}
+                                        <dd>{linksEntry $link}</dd>
+                                    {/if}
+                                {/foreach}
+                            </dl>
+                        </div>
+                    </div>
+                {/foreach}
 
                 <h3>Teacher{tif count($Section->Teachers) != 1 ? s}</h3>
                 <ul class="roster teachers">

--- a/php-classes/Slate/UI/SectionProfile.php
+++ b/php-classes/Slate/UI/SectionProfile.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Slate\UI;
+
+use Slate\Courses\Section;
+
+
+class SectionProfile
+{
+    public static $sources = [];
+
+    public static function getLinks(Section $Section)
+    {
+        return LinkUtil::mergeSources(static::$sources, $Section);
+    }
+}

--- a/php-classes/Slate/UI/UserProfile.php
+++ b/php-classes/Slate/UI/UserProfile.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Slate\UI;
+
+use Emergence\People\Person;
+
+
+class UserProfile
+{
+    public static $sources = [];
+
+    public static function getLinks(Person $Person)
+    {
+        return LinkUtil::mergeSources(static::$sources, $Person);
+    }
+}

--- a/php-config/Slate/UI/SectionProfile.config.d/launchers.php
+++ b/php-config/Slate/UI/SectionProfile.config.d/launchers.php
@@ -1,0 +1,13 @@
+<?php
+
+Slate\UI\SectionProfile::$sources[] = function (Slate\Courses\Section $Section) {
+    $links = [];
+
+    foreach ($Section->getLaunchers() AS $launcher) {
+        $links[$launcher['title']] = $launcher['url'];
+    }
+
+    return [
+        'Other Websites' => $links
+    ];
+};

--- a/php-config/Slate/UI/SectionProfile.config.d/tools.php
+++ b/php-config/Slate/UI/SectionProfile.config.d/tools.php
@@ -1,0 +1,17 @@
+<?php
+
+Slate\UI\SectionProfile::$sources[] = function (Slate\Courses\Section $Section) {
+    $links = [];
+
+    if (!empty($GLOBALS['Session']) && $GLOBALS['Session']->hasAccountLevel('Staff')) {
+        $links['Copy Email List'] = '#copy-section-emails';
+        $links['Download Roster'] = $Section->getUrl().'/students?'.http_build_query([
+            'format' => 'csv',
+            'columns' => 'LastName,FirstName,Gender,Username,PrimaryEmail,PrimaryPhone,StudentNumber,Advisor,GraduationYear'
+        ]);
+    }
+
+    return [
+        'Course Tools' => $links
+    ];
+};

--- a/php-migrations/Slate/Progress/20161116_notes-format.php
+++ b/php-migrations/Slate/Progress/20161116_notes-format.php
@@ -1,51 +1,5 @@
 <?php
 
-namespace Slate\Progress;
 
-use DB;
-use Slate\Progress\Narratives\Report;
-
-$tableName = Report::$tableName;
-$columnName = 'NotesFormat';
-$columnDefinition = "ENUM ('html', 'markdown') NULL DEFAULT 'markdown' AFTER `Notes`";
-
-// skip if people table not generated yet
-if (!static::tableExists($tableName)) {
-    print("Skipping migration because table `$tableName` doesn't exist yet\n");
-    return static::STATUS_SKIPPED;
-}
-
-if (static::columnExists($tableName, $columnName)) {
-    print("Skipping migration because column `$tableName`.`$columnName` exists already.");
-    return static::STATUS_SKIPPED;
-}
-
-// create column
-print("Adding column `$tableName`.`$columnName`");
-DB::nonQuery(
-    "ALTER TABLE `$tableName` ADD COLUMN `$columnName` $columnDefinition"
-);
-
-// create history table column
-print("Adding column `history_$tableName`.`$columnName`");
-DB::nonQuery(
-    "ALTER TABLE `history_$tableName` ADD COLUMN `$columnName` $columnDefinition"
-);
-
-// update values for records created before Sept. 2016, setting NotesFormat to HTML
-$oldTimestamp = strtotime("09/01/2016");
-$oldReportIds = DB::allValues(
-    'ID',
-    "SELECT ID FROM `$tableName` WHERE UNIX_TIMESTAMP(Created) < $oldTimestamp"
-);
-
-$totalReports = count($oldReportIds);
-if ($totalReports) {
-    print("Updating $totalReports reports format to 'html'");
-    DB::nonQuery(
-        "UPDATE `$tableName` SET NotesFormat = 'html' WHERE ID IN (%s)",
-        join(", ", $oldReportIds)
-    );
-}
-
-return static::STATUS_EXECUTED;
+print("Skipping migration for deprecated class");
+return static::STATUS_SKIPPED;


### PR DESCRIPTION
- Skip deprecated migration
- Add configure links to user and section profile pages
- Use `Site::$title` setting for site title