### PR TITLE
Release: slate v2.2.21

### DIFF
--- a/php-classes/Emergence/CRM/Message.php
+++ b/php-classes/Emergence/CRM/Message.php
@@ -199,8 +199,7 @@ class Message extends \VersionedRecord
 
             return count($newEmailRecipients);
         } else {
-            print_r(error_get_last());
-            throw new \Exception('Failed to inject message into email system');
+            throw new \Exception('Failed to inject message into email system:'.PHP_EOL.PHP_EOL.error_get_last());
         }
     }
 

--- a/php-classes/Slate/Progress/Note.php
+++ b/php-classes/Slate/Progress/Note.php
@@ -98,7 +98,7 @@ class Note extends \Emergence\CRM\Message implements IStudentTermReport
 
     public function getTimestamp()
     {
-        return $this->Sent;
+        return $this->Sent ?: $this->Modified ?: $this->Created;
     }
 
     public function getAuthor()

--- a/php-classes/Slate/Progress/ProgressRequestHandler.php
+++ b/php-classes/Slate/Progress/ProgressRequestHandler.php
@@ -82,12 +82,12 @@ class ProgressRequestHandler extends \RequestHandler
         // build cache of timestamps for quick sorting with no modification violations
         $recordTimestamps = [];
         foreach ($records AS $Record) {
-            $recordTimestamps[$Record->ID] = $Record->getTimestamp();
+            $recordTimestamps[$Record->getRootClass()][$Record->ID] = $Record->getTimestamp();
         }
 
         // apply unified sorting across all types
         usort($records, function ($r1, $r2) use($recordTimestamps) {
-            return $recordTimestamps[$r2->ID] - $recordTimestamps[$r1->ID];
+            return $recordTimestamps[$r2->getRootClass()][$r2->ID] - $recordTimestamps[$r1->getRootClass()][$r1->ID];
         });
 
         // return results and list of included types


### PR DESCRIPTION
- Fix issue sorting progress reports when entries of different type have same ID
- Include details in exceptions thrown when email sending  fails
- Fix missing timestamps for unsent progress notes