### PR TITLE
Release: slate v2.3.1

### DIFF
--- a/php-classes/Slate/Courses/SectionTermDataRequestHandler.php
+++ b/php-classes/Slate/Courses/SectionTermDataRequestHandler.php
@@ -2,6 +2,8 @@
 
 namespace Slate\Courses;
 
+use Slate\TermsRequestHandler;
+
 class SectionTermDataRequestHandler extends \RecordsRequestHandler
 {
     public static $recordClass = SectionTermData::class;
@@ -10,4 +12,30 @@ class SectionTermDataRequestHandler extends \RecordsRequestHandler
     public static $accountLevelWrite = 'Staff';
     public static $accountLevelRead = 'Staff';
     public static $accountLevelAPI = 'Staff';
+
+
+    public static function handleBrowseRequest($options = [], $conditions = [], $responseID = null, $responseData = [])
+    {
+        if (!empty($_GET['course_section'])) {
+            if (!$Section = SectionsRequestHandler::getRecordByHandle($_GET['course_section'])) {
+                return static::throwNotFoundError('course_section not found');
+            }
+
+            $conditions['SectionID'] = $Section->ID;
+        }
+
+        if (!empty($_GET['term'])) {
+            if ($_GET['term'] == 'current') {
+                if (!$Term = Term::getClosest()) {
+                    return static::throwInvalidRequestError('No current term could be found');
+                }
+            } elseif (!$Term = TermsRequestHandler::getRecordByHandle($_GET['term'])) {
+                return static::throwNotFoundError('term not found');
+            }
+
+            $conditions[] = sprintf('TermID IN (%s)', join(',', $Term->getRelatedTermIDs()));
+        }
+
+        return parent::handleBrowseRequest($options, $conditions, $responseID, $responseData);
+    }
 }

--- a/php-config/Git.config.d/slate-admin.php
+++ b/php-config/Git.config.d/slate-admin.php
@@ -7,6 +7,7 @@ Git::$repositories['slate-admin'] = [
     'trees' => [
         'docs/slate-admin',
         'html-templates/app/SlateAdmin',
+        'php-classes/SlateAdmin.php',
         'sencha-workspace/SlateAdmin' => [
             'exclude' => [
                 '#^/bootstrap\\.#' // don't sync generated bootstrap files

--- a/php-config/Git.config.d/slate.php
+++ b/php-config/Git.config.d/slate.php
@@ -15,6 +15,9 @@ Git::$repositories['slate'] = [
         ],
         'php-classes' => [
             'exclude' => [
+                // from slate-admin layer:
+                '#^/SlateAdmin\.php$#',
+
                 // from emergence-saml2 layer:
                 '#^/Emergence/SAML2(/|$)#',
 

--- a/site-root/sass/slate/_common.scss
+++ b/site-root/sass/slate/_common.scss
@@ -34,7 +34,7 @@ body {
 
 @if $hero-header-image {
     .site.header {
-        background-image: image-url('header.jpg');
+        background-image: $hero-header-image;
         background-size: cover;
         background-position: top;
         position: relative;


### PR DESCRIPTION
- Honor `$hero-header-image` value if set to different image path
- Restore course/term filters to section-data endpoint