### PR TITLE
Release: slate v2.3.5

### DIFF
--- a/html-templates/sections/courseSections.tpl
+++ b/html-templates/sections/courseSections.tpl
@@ -16,7 +16,7 @@
             {courseField blankOption='Any' default=$Course}
             {locationField blankOption='Any' default=$Location}
             {scheduleField blankOption='Any' default=$Schedule}
-            {checkbox inputName=enrolled_user value=current label='Only My Sections' default=$Course}
+            {checkbox inputName=enrolled_user value='*current' label='Only My Sections' default=$Course}
 
             <div class="submit-area">
                 <input type="submit" value="Apply Filters">

--- a/php-classes/Emergence/People/Person.php
+++ b/php-classes/Emergence/People/Person.php
@@ -294,20 +294,29 @@ class Person extends VersionedRecord implements IPerson
         return ($this->PreferredName ?: $this->FirstName).' '.$this->LastName;
     }
 
-    public function setValue($name, $value)
+    protected static function _relationshipExists($relationship)
     {
-        switch ($name) {
+        if ($relationship == 'Email') {
+            return true;
+        }
+
+        return parent::_relationshipExists($relationship);
+    }
+
+    protected function _setRelationshipValue($relationship, $value)
+    {
+        switch ($relationship) {
             case 'Email':
                 \Emergence\Logger::general_warning('Deprecated: Write on Person(#{PersonID})->Email, use ->PrimaryEmail = Email::fromString(...) instead', ['PersonID' => $this->ID]);
 
                 if (!$this->isPhantom) {
-                    $Existing = \Emergence\People\ContactPoint\Email::getByString($value, ['PersonID' => $this->ID]);
+                    $Existing = ContactPoint\Email::getByString($value, ['PersonID' => $this->ID]);
                 }
 
-                $this->PrimaryEmail = $Existing ? $Existing : \Emergence\People\ContactPoint\Email::fromString($value, $this, true);
+                $this->PrimaryEmail = $Existing ? $Existing : ContactPoint\Email::fromString($value, $this);
                 break;
             default:
-                return parent::setValue($name, $value);
+                return parent::_setRelationshipValue($relationship, $value);
         }
     }
 

--- a/php-classes/Emergence/People/RegistrationRequestHandler.php
+++ b/php-classes/Emergence/People/RegistrationRequestHandler.php
@@ -55,15 +55,15 @@ class RegistrationRequestHandler extends \RequestHandler
 
             // attach contact points
             if (!empty($_REQUEST['Email'])) {
-                $User->PrimaryEmail = \Emergence\People\ContactPoint\Email::fromString($_REQUEST['Email']);
+                $User->PrimaryEmail = ContactPoint\Email::fromString($_REQUEST['Email'], $User);
             }
 
             if (!empty($_REQUEST['Phone'])) {
-                $User->PrimaryPhone = \Emergence\People\ContactPoint\Phone::fromString($_REQUEST['Phone']);
+                $User->PrimaryPhone = ContactPoint\Phone::fromString($_REQUEST['Phone'], $User);
             }
 
             if (!empty($_REQUEST['Postal'])) {
-                $User->PrimaryPostal = \Emergence\People\ContactPoint\Postal::fromString($_REQUEST['Postal']);
+                $User->PrimaryPostal = ContactPoint\Postal::fromString($_REQUEST['Postal'], $User);
             }
 
             // save person fields

--- a/php-classes/Slate/Courses/SectionTermDataRequestHandler.php
+++ b/php-classes/Slate/Courses/SectionTermDataRequestHandler.php
@@ -25,7 +25,7 @@ class SectionTermDataRequestHandler extends \RecordsRequestHandler
         }
 
         if (!empty($_GET['term'])) {
-            if ($_GET['term'] == 'current') {
+            if ($_GET['term'] == '*current') {
                 if (!$Term = Term::getClosest()) {
                     return static::throwInvalidRequestError('No current term could be found');
                 }

--- a/php-classes/Slate/Courses/SectionsRequestHandler.php
+++ b/php-classes/Slate/Courses/SectionsRequestHandler.php
@@ -44,7 +44,7 @@ class SectionsRequestHandler extends \RecordsRequestHandler
 
     public static function handleBrowseRequest($options = [], $conditions = [], $responseID = null, $responseData = [])
     {
-        if (empty($_REQUEST['term']) || $_REQUEST['term'] == 'current') {
+        if (empty($_REQUEST['term']) || $_REQUEST['term'] == '*current') {
             if (!$Term = Term::getClosest()) {
                 return static::throwInvalidRequestError('No current term could be found');
             }
@@ -87,7 +87,7 @@ class SectionsRequestHandler extends \RecordsRequestHandler
         }
 
         if (!empty($_REQUEST['enrolled_user'])) {
-            if ($_REQUEST['enrolled_user'] == 'current') {
+            if ($_REQUEST['enrolled_user'] == '*current') {
                 $GLOBALS['Session']->requireAuthentication();
                 $EnrolledUser = $GLOBALS['Session']->Person;
             } elseif (!$EnrolledUser = User::getByHandle($_REQUEST['enrolled_user'])) {

--- a/php-classes/Slate/Progress/NotesRequestHandler.php
+++ b/php-classes/Slate/Progress/NotesRequestHandler.php
@@ -36,8 +36,6 @@ class NotesRequestHandler extends \Emergence\CRM\MessagesRequestHandler
                 return static::handleProgressNotesRequest();
             case 'recipients':
                 return static::handleRecipientsRequest();
-            case 'addCustomRecipient':
-                return static::handleCustomRecipientRequest();
             default:
                 return parent::handleRecordsRequest($action);
         }
@@ -238,37 +236,6 @@ class NotesRequestHandler extends \Emergence\CRM\MessagesRequestHandler
         }
 
         return parent::respond($responseID, $responseData);
-    }
-
-    public static function handleCustomRecipientRequest()
-    {
-        if (!empty($_REQUEST['Person']) && !empty($_REQUEST['Email']) && !empty($_REQUEST['StudentID'])) {
-            if (!is_numeric($_REQUEST['Person'])) {
-                $nameData = Person::parseFullName($_REQUEST['Person']);
-
-                $recipientData = ['Email' => $_REQUEST['Email']];
-
-                if ($RecipientPerson = Person::getByFullName($nameData['FirstName'], $nameData['LastName'])) {
-                    if (!$EmailContactPoint = \Emergence\People\ContactPoint\Email::getByWhere(['PersonID'=>$RecipientPerson->ID, 'Data'=>serialize($_REQUEST['Email'])])) {
-                        return static::throwError($RecipientPerson->FullName.' exists in the database already. Please select user from combo or use a different name');
-                    }
-                } else {
-                    $RecipientPerson = Person::create(array_merge($recipientData, $nameData), true);
-                }
-            } else {
-                $RecipientPerson = Person::getByID($_REQUEST['Person']);
-            }
-
-            $recipient = static::_getRecipientFromPerson($RecipientPerson, [
-                'label' => !empty($_REQUEST['Label']) ? $_REQUEST['Label'] : null,
-                'email' => $_REQUEST['Email'] != $RecipientPerson->Email ? $_REQUEST['Email'] : null
-            ]);
-
-            return static::respond('notes', [
-                'success' => true,
-                'data' => $recipient
-            ]);
-        }
     }
 
     protected static function _getRecipientFromPerson(Person $Person, array $options = [])

--- a/php-classes/Slate/Progress/NotesRequestHandler.php
+++ b/php-classes/Slate/Progress/NotesRequestHandler.php
@@ -259,22 +259,9 @@ class NotesRequestHandler extends \Emergence\CRM\MessagesRequestHandler
                 $RecipientPerson = Person::getByID($_REQUEST['Person']);
             }
 
-            $email = ($RecipientPerson->Email == $_REQUEST['Email']) ? false : $_REQUEST['Email'];
-            $label = !empty($_REQUEST['Label']) ? $_REQUEST['Label'] : null;
-
-            if ($_REQUEST['Relationship']) {
-                if (!$Relationship = Relationship::getByWhere(['PersonID'=>$_REQUEST['StudentID'], 'RelatedPersonID' => $RecipientPerson->ID])) {
-                    $Relationship = Relationship::create([
-                        'PersonID' => $_REQUEST['StudentID'],
-                        'RelatedPersonID' => $RecipientPerson->ID,
-                        'Label' => $label
-                    ], true);
-                }
-            }
-
             $recipient = static::_getRecipientFromPerson($RecipientPerson, [
-                'label' => $label,
-                'email' => $email
+                'label' => !empty($_REQUEST['Label']) ? $_REQUEST['Label'] : null,
+                'email' => $_REQUEST['Email'] != $RecipientPerson->Email ? $_REQUEST['Email'] : null
             ]);
 
             return static::respond('notes', [

--- a/php-classes/Slate/Progress/NotesRequestHandler.php
+++ b/php-classes/Slate/Progress/NotesRequestHandler.php
@@ -7,6 +7,7 @@ use Emergence\People\User;
 use Emergence\People\Relationship;
 
 use Emergence\CRM\Message;
+use Emergence\CRM\MessageRecipient;
 use Emergence\CRM\GlobalRecipient;
 
 use Slate\People\Student;
@@ -45,7 +46,10 @@ class NotesRequestHandler extends \Emergence\CRM\MessagesRequestHandler
     public static function handleProgressNotesRequest()
     {
         if (!empty($_REQUEST['messageID'])) {
-            $Message = Message::getByID($_REQUEST['messageID']);
+            if (!$Message = Message::getByID($_REQUEST['messageID'])) {
+                return static::throwNotFoundError('Message not found');
+            }
+
             $Person = Person::getByID($Message->ContextID);
         }
 
@@ -75,17 +79,37 @@ class NotesRequestHandler extends \Emergence\CRM\MessagesRequestHandler
     public static function handleRecipientsRequest($Person = false, $Message = false)
     {
         if (!$Person && !($Person = Person::getByID($_REQUEST['personID']))) {
-            return static::throwError('Person not found');
+            return static::throwNotFoundError('Person not found');
         }
 
         if (!$Message && !empty($_REQUEST['messageID'])) {
-            $Message = Message::getByID($_REQUEST['messageID']);
+            if (!$Message = Message::getByID($_REQUEST['messageID'])) {
+                return static::throwNotFoundError('Message not found');
+            }
         }
 
-        // build list of suggested recipients
-        $contacts = [];
 
-        // instructors
+        // collect existing recipients by Person ID
+        $recipients = [];
+        if ($Message) {
+            foreach ($Message->Recipients as $Recipient) {
+                $recipients[$Recipient->PersonID] = [
+                    'Recipient' => $Recipient,
+                    'matched' => false
+                ];
+            }
+        }
+
+
+        // build list of suggested recipients, starting with the target person
+        $contacts = [
+            static::_getRecipientFromPerson($Person, [
+                'label' => $Person->isA(Student::class) ? 'Student' : 'User',
+                'recipients' => &$recipients
+            ])
+        ];
+
+        // teachers
         if ($Term = Term::getClosest()) {
             $studentInstructors = \DB::allRecords(
                 'SELECT TeacherPart.PersonID AS instructorID, GROUP_CONCAT(TeacherPart.CourseSectionID SEPARATOR ",") AS sectionIDs'
@@ -107,57 +131,61 @@ class NotesRequestHandler extends \Emergence\CRM\MessagesRequestHandler
                     return Section::getByID($sectionID)->Course->Code;
                 }, explode(',', $si['sectionIDs']));
 
-                $contacts[$si['instructorID']] = static::_getRecipientFromPerson(Person::getByID($si['instructorID']), 'Teacher ('.join(', ',$sectionCodes).')', 'Teachers');
+                $contacts[] = static::_getRecipientFromPerson(Person::getByID($si['instructorID']), [
+                    'group' => 'Teachers',
+                    'label' => 'Teacher ('.join(', ',$sectionCodes).')',
+                    'recipients' => &$recipients
+                ]);
             }
         }
 
         // advisor
         if ($Person->AdvisorID) {
-            if (isset($contacts[$Person->AdvisorID])) {
-                $contacts[$Person->AdvisorID]['Label'] = 'Advisor, '.$contacts[$Person->AdvisorID]['Label'];
-            } else {
-                $contacts[$Person->AdvisorID] = static::_getRecipientFromPerson($Person->Advisor, 'Advisor', 'Teachers');
-            }
+            $contacts[] = static::_getRecipientFromPerson($Person->Advisor, [
+                'group' => 'School Contacts',
+                'label' => 'Advisor',
+                'recipients' => &$recipients
+            ]);
         }
 
         // school-wide staff
-        foreach (GlobalRecipient::getAll() AS $globalRecipient) {
-            $contacts[$globalRecipient->PersonID] = static::_getRecipientFromPerson(Person::getByID($globalRecipient->PersonID), $globalRecipient->Title, 'Global Recipients');
+        foreach (GlobalRecipient::getAll() as $globalRecipient) {
+            $contacts[] = static::_getRecipientFromPerson(Person::getByID($globalRecipient->PersonID), [
+                'group' => 'School Contacts',
+                'label' => $globalRecipient->Title,
+                'recipients' => &$recipients
+            ]);
         }
 
         // related contacts
-        foreach (Relationship::getAllByPerson($Person) AS $Relationship) {
-            if (!$Relationship->RelatedPerson->Email) {
+        foreach ($Person->Relationships as $Relationship) {
+            $contacts[] = static::_getRecipientFromPerson($Relationship->RelatedPerson, [
+                'group' => 'Related Contacts',
+                'label' => $Relationship->Label,
+                'recipients' => &$recipients
+            ]);
+        }
+
+
+        // add any additional recipients
+        foreach ($recipients as $recipient) {
+            if ($recipient['matched']) {
                 continue;
             }
 
-            $contacts[$Relationship->RelatedPersonID] = static::_getRecipientFromPerson($Relationship->RelatedPerson, $Relationship->Label, 'Related Contacts');
+            $contacts[] = static::_getRecipientFromPerson($recipient['Recipient']->Person, [
+                'recipients' => &$recipients
+            ]);
         }
 
-        // the target person
-        $contacts[$Person->ID] = static::_getRecipientFromPerson($Person, ($Person->isA(Student::class) ? 'Student' : 'User'));
-
-        // mark recieved recipients
-        if ($Message) {
-            $contactStatus = [];
-
-            foreach ($Message->Recipients AS $Recipient) {
-                if (!isset($contacts[$Recipient->PersonID])) {
-                    $contacts[$Recipient->PersonID] = static::_getRecipientFromPerson($Recipient->Person, 'Message Recipient');
-                    
-                }
-                
-                $contacts[$Recipient->PersonID]['Status'] = $Recipient->Status;
-                $contacts[$Recipient->PersonID]['Email'] = $Recipient->EmailContact->toString();
-            }
-        }
 
         return static::respond('noteRecipients', [
             'success' => true,
-            'data' => array_values($contacts)
+            'data' => $contacts
         ]);
     }
 
+    // TODO: delete this?
     public static function respond($responseID, $responseData = [], $responseMode = false)
     {
         $className = static::$recordClass;
@@ -232,18 +260,22 @@ class NotesRequestHandler extends \Emergence\CRM\MessagesRequestHandler
             }
 
             $email = ($RecipientPerson->Email == $_REQUEST['Email']) ? false : $_REQUEST['Email'];
+            $label = !empty($_REQUEST['Label']) ? $_REQUEST['Label'] : null;
 
             if ($_REQUEST['Relationship']) {
                 if (!$Relationship = Relationship::getByWhere(['PersonID'=>$_REQUEST['StudentID'], 'RelatedPersonID' => $RecipientPerson->ID])) {
                     $Relationship = Relationship::create([
                         'PersonID' => $_REQUEST['StudentID'],
                         'RelatedPersonID' => $RecipientPerson->ID,
-                        'Label' => $_REQUEST['Label']
+                        'Label' => $label
                     ], true);
                 }
             }
 
-            $recipient = static::_getRecipientFromPerson($RecipientPerson, $Relationship->Label, 'Other', $email);
+            $recipient = static::_getRecipientFromPerson($RecipientPerson, [
+                'label' => $label,
+                'email' => $email
+            ]);
 
             return static::respond('notes', [
                 'success' => true,
@@ -252,14 +284,26 @@ class NotesRequestHandler extends \Emergence\CRM\MessagesRequestHandler
         }
     }
 
-    protected static function _getRecipientFromPerson(Person $Person, $relationship = null, $relationshipGroup = null, $email = null)
+    protected static function _getRecipientFromPerson(Person $Person, array $options = [])
     {
-        return [
+        $data = [
             'PersonID' => $Person->ID,
             'FullName' => $Person->FullName,
-            'Email' => !$email ? $Person->Email : $email,
-            'Label' => $relationship,
-            'RelationshipGroup' => $relationshipGroup
+            'Email' => !empty($options['email']) ? $options['email'] : ($Person->PrimaryEmail ? $Person->PrimaryEmail->toString() : null),
+            'Label' => !empty($options['label']) ? $options['label'] : null,
+            'RelationshipGroup' => !empty($options['group']) ? $options['group'] : null,
+            'Status' => null
         ];
+
+        if (!empty($options['recipients']) && !empty($options['recipients'][$Person->ID])) {
+            $Recipient = $options['recipients'][$Person->ID]['Recipient'];
+
+            $data['Email'] = $Recipient->EmailContact->toString();
+            $data['Status'] = $Recipient->Status;
+
+            $options['recipients'][$Person->ID]['matched'] = true;
+        }
+
+        return $data;
     }
 }


### PR DESCRIPTION
- Change `current` pseudo-values to collision-immune `*current`
- Fix error setting email during self-registration (when enabled)
- Fix changing email address from standard profile page
- Support new workflows for custom progress note recipients