### PR TITLE
Release: slate v2.7.5

### DIFF
--- a/project-all.sh
+++ b/project-all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+git holo project emergence-skeleton \
+    --fetch \
+    --ref=origin/releases/v2 \
+    --commit-to=emergence/skeleton/v2
+
+git holo project emergence-vfs-site \
+    --fetch \
+    --ref=origin/releases/v2 \
+    --commit-to=emergence/vfs-site/v2
+
+git holo project emergence-vfs-skeleton \
+    --fetch \
+    --ref=origin/releases/v2 \
+    --commit-to=emergence/vfs-skeleton/v2

--- a/sencha-workspace/SlateAdmin/app/controller/people/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/controller/people/Courses.js
@@ -64,19 +64,23 @@ Ext.define('SlateAdmin.controller.people.Courses', {
             return;
         }
 
-        if (!selectedTerm) {
-            selectedTerm = termsStore.getCurrentTerm();
+        if (
+            !selectedTerm
+            && (selectedTerm = termsStore.getCurrentTerm())
+        ) {
+            // push selected term to combo
+            termSelector.setSelection(selectedTerm);
+
+            // switch to int
+            selectedTerm = selectedTerm.getId();
         }
 
         coursesPanel.setLoading(false);
 
         // configure proxy and load store
         personSectionsProxy.url = '/people/' + person.get('ID') + '/courses';
-        personSectionsProxy.setExtraParam('termID', selectedTerm ? selectedTerm.getId() : null);
+        personSectionsProxy.setExtraParam('termID', selectedTerm || null);
         personSectionsStore.load();
-
-        // push selected term to combo
-        termSelector.setValue(selectedTerm);
     },
 
     onCourseTermSelect: function(field, newValue, oldValue) {

--- a/sencha-workspace/SlateAdmin/app/controller/people/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/controller/people/Courses.js
@@ -55,11 +55,14 @@ Ext.define('SlateAdmin.controller.people.Courses', {
         // ensure terms are loaded
         if (!termsStore.isLoaded()) {
             coursesPanel.setLoading('Loading terms&hellip;');
-            termsStore.load({
-                callback: function() {
-                    me.onPersonLoaded(coursesPanel, person);
-                }
-            });
+            termsStore.on('load', function() {
+                coursesPanel.setLoading(false);
+                me.onPersonLoaded(coursesPanel, person);
+            }, me, { single: true });
+
+            if (!termsStore.isLoading()) {
+                termsStore.load();
+            }
 
             return;
         }
@@ -75,7 +78,6 @@ Ext.define('SlateAdmin.controller.people.Courses', {
             selectedTerm = selectedTerm.getId();
         }
 
-        coursesPanel.setLoading(false);
 
         // configure proxy and load store
         personSectionsProxy.url = '/people/' + person.get('ID') + '/courses';

--- a/sencha-workspace/SlateAdmin/app/controller/people/Profile.js
+++ b/sencha-workspace/SlateAdmin/app/controller/people/Profile.js
@@ -100,10 +100,6 @@ Ext.define('SlateAdmin.controller.people.Profile', {
             siteUserAccountLevel = siteEnv.user && siteEnv.user.AccountLevel,
             siteUserIsAdmin = siteUserAccountLevel == 'Administrator' || siteUserAccountLevel == 'Developer';
 
-        me.getTemporaryPasswordFieldCt().setVisible(siteUserIsAdmin);
-        me.getUsernameField().setReadOnly(!siteUserIsAdmin);
-        me.getMasqueradeBtnCt().setVisible(siteUserIsAdmin && person.get('Username'));
-
         profilePanel.setLoading('Loading&hellip;');
         Ext.StoreMgr.requireLoaded([
             'people.Classes',
@@ -111,9 +107,17 @@ Ext.define('SlateAdmin.controller.people.Profile', {
             'people.AccountLevels',
             'people.Advisors'
         ], function() {
+            var temporaryPasswordFieldCt = me.getTemporaryPasswordFieldCt();
+            Ext.suspendLayouts();
+
             profileForm.loadRecord(person);
-            profilePanel.setLoading(false);
+            temporaryPasswordFieldCt.setVisible(temporaryPasswordFieldCt.isVisible() && siteUserIsAdmin);
+            me.getUsernameField().setReadOnly(!siteUserIsAdmin);
+            me.getMasqueradeBtnCt().setVisible(siteUserIsAdmin && person.get('Username'));
             me.syncButtons();
+            profilePanel.setLoading(false);
+
+            Ext.resumeLayouts(true);
         });
     },
 

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Report.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Report.js
@@ -523,7 +523,7 @@ Ext.define('SlateAdmin.controller.progress.interims.Report', {
             managerCt = me.getManagerCt(),
             myClassesOnlyCheckbox = me.getMyClassesOnlyCheckbox(),
             termSelector = me.getTermSelector(),
-            termsStore = termSelector.getStore(),
+            termsStore = me.getTermsStore(),
             term = termSelector.getValue();
 
         // ensure terms are loaded
@@ -544,7 +544,7 @@ Ext.define('SlateAdmin.controller.progress.interims.Report', {
         if (!term) {
             term = termsStore.getReportingTerm() || termsStore.getCurrentTerm();
             if (term) {
-                termSelector.setValue(term);
+                termSelector.setSelection(term);
             } else {
                 Ext.Msg.alert('No term available', 'No current or reporting term could be detected, please select a term');
             }

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Report.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Report.js
@@ -528,6 +528,7 @@ Ext.define('SlateAdmin.controller.progress.interims.Report', {
 
         // ensure terms are loaded
         if (!termsStore.isLoaded()) {
+            managerCt.setLoading('Loading terms&hellip;');
             termsStore.on('load', function() {
                 managerCt.setLoading(false);
                 me.syncSections();

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Report.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Report.js
@@ -529,6 +529,7 @@ Ext.define('SlateAdmin.controller.progress.terms.Report', {
 
         // ensure terms are loaded
         if (!termsStore.isLoaded()) {
+            managerCt.setLoading('Loading terms&hellip;');
             termsStore.on('load', function() {
                 managerCt.setLoading(false);
                 me.syncSections();

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Report.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Report.js
@@ -524,7 +524,7 @@ Ext.define('SlateAdmin.controller.progress.terms.Report', {
             managerCt = me.getManagerCt(),
             myClassesOnlyCheckbox = me.getMyClassesOnlyCheckbox(),
             termSelector = me.getTermSelector(),
-            termsStore = termSelector.getStore(),
+            termsStore = me.getTermsStore(),
             term = termSelector.getValue();
 
         // ensure terms are loaded
@@ -545,7 +545,7 @@ Ext.define('SlateAdmin.controller.progress.terms.Report', {
         if (!term) {
             term = termsStore.getReportingTerm() || termsStore.getCurrentTerm();
             if (term) {
-                termSelector.setValue(term);
+                termSelector.setSelection(term);
             } else {
                 Ext.Msg.alert('No term available', 'No current or reporting term could be detected, please select a term');
             }

--- a/sencha-workspace/SlateAdmin/app/view/Navigation.js
+++ b/sencha-workspace/SlateAdmin/app/view/Navigation.js
@@ -11,5 +11,11 @@ Ext.define('SlateAdmin.view.Navigation', {
     width: 200,
     layout: {
         type: 'accordion'
-    }
+    },
+    items: [{
+        // dummy first item so the rest can start collapsed
+        xtype: 'panel',
+        hidden: true,
+        collapsed: false
+    }]
 });

--- a/sencha-workspace/SlateAdmin/app/view/courses/NavPanel.js
+++ b/sencha-workspace/SlateAdmin/app/view/courses/NavPanel.js
@@ -4,6 +4,7 @@ Ext.define('SlateAdmin.view.courses.NavPanel', {
     xtype: 'courses-navpanel',
     requires: [
         'Ext.form.Panel',
+        'Ext.data.ChainedStore',
         'Jarvus.ext.form.field.Search'
     ],
 
@@ -77,8 +78,11 @@ Ext.define('SlateAdmin.view.courses.NavPanel', {
         name: 'department',
         fieldLabel: 'Dept.',
 
+        store: {
+            type: 'chained',
+            source: 'courses.Departments'
+        },
         queryMode: 'local',
-        store: 'courses.Departments',
         valueField: 'Handle',
         displayField: 'Title',
 
@@ -88,8 +92,11 @@ Ext.define('SlateAdmin.view.courses.NavPanel', {
         name: 'term',
         fieldLabel: 'Term',
 
+        store: {
+            type: 'chained',
+            source: 'Terms'
+        },
         queryMode: 'local',
-        store: 'Terms',
         valueField: 'Handle',
         displayField: 'Title',
 
@@ -99,8 +106,11 @@ Ext.define('SlateAdmin.view.courses.NavPanel', {
         name: 'schedule',
         fieldLabel: 'Schedule',
 
+        store: {
+            type: 'chained',
+            source: 'courses.Schedules'
+        },
         queryMode: 'local',
-        store: 'courses.Schedules',
         valueField: 'Handle',
         displayField: 'Title',
 
@@ -110,8 +120,11 @@ Ext.define('SlateAdmin.view.courses.NavPanel', {
         name: 'location',
         fieldLabel: 'Location',
 
+        store: {
+            type: 'chained',
+            source: 'Locations'
+        },
         queryMode: 'local',
-        store: 'Locations',
         valueField: 'Handle',
         displayField: 'Title',
 

--- a/sencha-workspace/SlateAdmin/app/view/people/details/Progress.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/details/Progress.js
@@ -2,7 +2,8 @@ Ext.define('SlateAdmin.view.people.details.Progress', {
     extend: 'SlateAdmin.view.people.details.AbstractDetails',
     xtype: 'people-details-progress',
     requires: [
-        'Ext.grid.Panel'
+        'Ext.grid.Panel',
+        'Ext.data.ChainedStore'
     ],
 
 
@@ -57,10 +58,15 @@ Ext.define('SlateAdmin.view.people.details.Progress', {
             xtype: 'combobox',
             itemId: 'termSelector',
             emptyText: 'Any',
-            store: 'Terms',
+
+            store: {
+                type: 'chained',
+                source: 'Terms'
+            },
+            queryMode: 'local',
             valueField: 'Handle',
             displayField: 'Title',
-            queryMode: 'local',
+
             forceSelection: true
         }]
     }, {

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Container.js
@@ -10,7 +10,8 @@ Ext.define('SlateAdmin.view.progress.interims.email.Container', {
         'Ext.form.field.ComboBox',
         'Ext.form.CheckboxGroup',
         'Ext.toolbar.Fill',
-        'Ext.toolbar.Separator'
+        'Ext.toolbar.Separator',
+        'Ext.data.ChainedStore'
     ],
 
 
@@ -50,7 +51,10 @@ Ext.define('SlateAdmin.view.progress.interims.email.Container', {
                             fieldLabel: 'Term',
                             emptyText: 'Current Term',
 
-                            store: 'Terms',
+                            store: {
+                                type: 'chained',
+                                source: 'Terms'
+                            },
                             displayField: 'Title',
                             valueField: 'Handle'
                         },
@@ -81,9 +85,12 @@ Ext.define('SlateAdmin.view.progress.interims.email.Container', {
                             name: 'group',
                             fieldLabel: 'Group',
 
-                            store: 'people.Groups',
-                            displayField: 'namesPath',
-                            valueField: 'Handle'
+                            store: {
+                                type: 'chained',
+                                source: 'people.Groups'
+                            },
+                            valueField: 'Handle',
+                            displayField: 'namesPath'
                         }
                     ]
                 },

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/SectionsGrid.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/SectionsGrid.js
@@ -3,7 +3,8 @@ Ext.define('SlateAdmin.view.progress.terms.SectionsGrid', {
     xtype: 'progress-terms-sectionsgrid',
     requires: [
         'Ext.form.field.ComboBox',
-        'Ext.form.field.Checkbox'
+        'Ext.form.field.Checkbox',
+        'Ext.data.ChainedStore'
     ],
 
 
@@ -22,10 +23,14 @@ Ext.define('SlateAdmin.view.progress.terms.SectionsGrid', {
 
                     xtype: 'combobox',
 
+                    store: {
+                        type: 'chained',
+                        source: 'Terms'
+                    },
                     queryMode: 'local',
-                    store: 'Terms',
                     valueField: 'Handle',
                     displayField: 'Title',
+
                     forceSelection: true
                 }
             ]

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Container.js
@@ -10,7 +10,8 @@ Ext.define('SlateAdmin.view.progress.terms.email.Container', {
         'Ext.form.field.ComboBox',
         'Ext.form.CheckboxGroup',
         'Ext.toolbar.Fill',
-        'Ext.toolbar.Separator'
+        'Ext.toolbar.Separator',
+        'Ext.data.ChainedStore'
     ],
 
 
@@ -50,9 +51,12 @@ Ext.define('SlateAdmin.view.progress.terms.email.Container', {
                             fieldLabel: 'Term',
                             emptyText: 'Current Term',
 
-                            store: 'Terms',
-                            displayField: 'Title',
-                            valueField: 'Handle'
+                            store: {
+                                type: 'chained',
+                                source: 'Terms'
+                            },
+                            valueField: 'Handle',
+                            displayField: 'Title'
                         },
                         {
                             name: 'advisor',
@@ -81,9 +85,12 @@ Ext.define('SlateAdmin.view.progress.terms.email.Container', {
                             name: 'group',
                             fieldLabel: 'Group',
 
-                            store: 'people.Groups',
-                            displayField: 'namesPath',
-                            valueField: 'Handle'
+                            store: {
+                                type: 'chained',
+                                source: 'people.Groups'
+                            },
+                            valueField: 'Handle',
+                            displayField: 'namesPath'
                         }
                     ]
                 },

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/print/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/print/Container.js
@@ -9,7 +9,8 @@ Ext.define('SlateAdmin.view.progress.terms.print.Container', {
         'Ext.form.field.ComboBox',
         'Ext.form.field.Checkbox',
         'Ext.toolbar.Fill',
-        'Ext.toolbar.Separator'
+        'Ext.toolbar.Separator',
+        'Ext.data.ChainedStore'
     ],
 
 
@@ -51,9 +52,12 @@ Ext.define('SlateAdmin.view.progress.terms.print.Container', {
                             fieldLabel: 'Term',
                             emptyText: 'Current Term',
 
-                            store: 'Terms',
-                            displayField: 'Title',
-                            valueField: 'Handle'
+                            store: {
+                                type: 'chained',
+                                source: 'Terms'
+                            },
+                            valueField: 'Handle',
+                            displayField: 'Title'
                         },
                         {
                             name: 'advisor',
@@ -82,9 +86,12 @@ Ext.define('SlateAdmin.view.progress.terms.print.Container', {
                             name: 'group',
                             fieldLabel: 'Group',
 
-                            store: 'people.Groups',
-                            displayField: 'namesPath',
-                            valueField: 'Handle'
+                            store: {
+                                type: 'chained',
+                                source: 'people.Groups'
+                            },
+                            valueField: 'Handle',
+                            displayField: 'namesPath'
                         },
                         {
                             name: 'status',

--- a/sencha-workspace/SlateAdmin/app/view/settings/terms/Manager.js
+++ b/sencha-workspace/SlateAdmin/app/view/settings/terms/Manager.js
@@ -12,7 +12,14 @@ Ext.define('SlateAdmin.view.settings.terms.Manager', {
     rootVisible: false,
     store: {
         type: 'emergence-chainedtree',
-        source: 'Terms'
+        source: 'Terms',
+        sorters: [{
+            property: 'masterStartDate',
+            direction: 'DESC'
+        },{
+            property: 'Left',
+            direction: 'ASC'
+        }]
     },
     viewConfig: {
         toggleOnDblClick: false

--- a/sencha-workspace/dev-loader.js
+++ b/sencha-workspace/dev-loader.js
@@ -1,5 +1,6 @@
 (() => {
     const [,apiHost] = location.search.match(/[?&]apiHost=([^&]+)/) || [];
+    const [,apiSSL] = location.search.match(/[?&]apiSSL=([^&]+)/) || [];
 
     if (!apiHost) {
         document.body.innerHTML = 'Page must be loaded with <code>?apiHost=slate.example.org</code> set'
@@ -12,7 +13,7 @@
         const xhr = new XMLHttpRequest();
         xhr.responseType = 'document';
         xhr.withCredentials = true;
-        xhr.open('GET', `http://${apiHost}${framePath}`);
+        xhr.open('GET', `http${apiSSL?'s':''}://${apiHost}${framePath}`);
         xhr.onload = () => {
             if (xhr.status === 200) {
                 // graft head elements

--- a/sencha-workspace/dev-loader.js
+++ b/sencha-workspace/dev-loader.js
@@ -21,15 +21,24 @@
                     .querySelectorAll('head > *:not([href^="/webapps/"])')
                     .forEach(node => {
                         _patchHeadElement(node);
-                        document.head.appendChild(node)
+                        document.head.appendChild(node);
                     });
 
                 // graft body elements
                 xhr.response
-                    .querySelectorAll('body > *:not([src^="/webapps/"])')
+                    .querySelectorAll('body > *:not(script)')
                     .forEach(node => {
                         _patchBodyElement(node);
-                        document.body.appendChild(node)
+                        document.body.appendChild(node);
+                    });
+
+                // graft environmental data
+                xhr.response
+                    .querySelectorAll('script')
+                    .forEach(node => {
+                        if (node.textContent.match(/window\.SiteEnvironment\W/)) {
+                            eval(node.textContent)
+                        }
                     });
 
                 // finally: load app

--- a/sencha-workspace/packages/slate-core-data/src/model/Term.js
+++ b/sencha-workspace/packages/slate-core-data/src/model/Term.js
@@ -115,6 +115,12 @@ Ext.define('Slate.model.Term', {
                     return r.get('Left') == r.get('Right') - 1;
                 }
             }
+        },
+        {
+            name: 'masterStartDate',
+            type: 'date',
+            persist: false,
+            allowNull: true
         }
     ],
 

--- a/sencha-workspace/packages/slate-core-data/src/model/person/Group.js
+++ b/sencha-workspace/packages/slate-core-data/src/model/person/Group.js
@@ -91,14 +91,33 @@ Ext.define('Slate.model.person.Group', {
         },
 
         // virtual fields
-        // TOOD: test if still needed
+        {
+            name: 'namesStack',
+            persist: false,
+            depends: ['Name'],
+            convert: function (v, r) {
+                var name = r.get('Name');
+
+                if (!v) {
+                    return [name];
+                }
+
+                v.pop();
+                v.push(name);
+
+                return v;
+            },
+            isEqual: function (a, b) {
+                return Ext.Array.equals(a, b);
+            }
+        },
         {
             name: 'namesPath',
             type: 'string',
             persist: false,
-            depends: ['Name'],
+            depends: ['namesStack'],
             convert: function (v, r) {
-                return v ? v.replace(/[^\/]+$/, r.get('Name')) : null;
+                return r.get('namesStack').join(' ▸ ');
             }
         },
         {

--- a/sencha-workspace/packages/slate-core-data/src/model/person/Group.js
+++ b/sencha-workspace/packages/slate-core-data/src/model/person/Group.js
@@ -102,7 +102,7 @@ Ext.define('Slate.model.person.Group', {
                     return [name];
                 }
 
-                v.pop();
+                v = v.slice(0, -1);
                 v.push(name);
 
                 return v;

--- a/sencha-workspace/packages/slate-core-data/src/store/Terms.js
+++ b/sencha-workspace/packages/slate-core-data/src/store/Terms.js
@@ -24,7 +24,7 @@ Ext.define('Slate.store.Terms', {
 
     // config handlers
     applyCurrentTerm: function (value) {
-        return typeof value == 'number' ? this.getById(value) : value;
+        return (typeof value == 'number' ? this.getById(value) : value) || null;
     },
 
     updateCurrentTerm: function (newValue, oldValue) {
@@ -32,45 +32,59 @@ Ext.define('Slate.store.Terms', {
     },
 
     applyReportingTerm:  function (value) {
-        return typeof value == 'number' ? this.getById(value) : value;
+        return (typeof value == 'number' ? this.getById(value) : value) || null;
     },
 
     updateReportingTerm: function (newValue, oldValue) {
         this.fireEvent('currentreportingchange', this, newValue, oldValue);
     },
 
-    // TODO: replace these with onProxyLoad handler that stashes them in evented config?
-    getCurrentTerm: function() {
-        var me = this,
-            rawData = me.getProxy().getReader().rawData,
-            termId = rawData && rawData.currentTerm;
-
-        return (termId && me.getById(termId)) || null;
-    },
-
-    getReportingTerm: function() {
-        var me = this,
-            rawData = me.getProxy().getReader().rawData,
-            termId = rawData && rawData.reportingTerm;
-
-        return (termId && me.getById(termId)) || null;
-    },
-
     onProxyLoad: function(operation) {
-        var me = this,
-            rawData = operation.getProxy().getReader().rawData;
+        var me = this;
 
-        // let store load first so we can look up IDs
-        me.callParent(arguments);
+        if (!me.destroyed && operation.wasSuccessful()) {
+            const records = operation.getRecords();
+            const rawData = operation.getProxy().getReader().rawData;
 
-        if (rawData) {
-            if ('currentTerm' in rawData) {
-                me.setCurrentTerm(rawData.currentTerm);
+            // build an initial map of records by id
+            const byId = {};
+
+            for (const record of records) {
+                byId[record.getId()] = record;
             }
 
-            if ('reportingTerm' in rawData) {
-                me.setReportingTerm(rawData.reportingTerm);
+
+            // load current/reporting term metadata directly from response
+            if (rawData) {
+                if ('currentTerm' in rawData) {
+                    me.setCurrentTerm(byId[rawData.currentTerm]);
+                }
+
+                if ('reportingTerm' in rawData) {
+                    me.setReportingTerm(byId[rawData.reportingTerm]);
+                }
+            }
+
+
+            // decorate dataset with hierarchy metadata
+            for (const record of records) {
+                let parentId = record.get('ParentID');
+                let parentRecord = null;
+
+                while (parentId) {
+                    parentRecord = byId[parentId];
+
+                    if (!parentRecord) {
+                        break;
+                    }
+
+                    parentId = parentRecord.get('ParentID');
+                }
+
+                record.set('masterStartDate', (parentRecord||record).get('StartDate'), { commit: true });
             }
         }
+
+        me.callParent(arguments);
     }
 });

--- a/sencha-workspace/packages/slate-core-data/src/store/Terms.js
+++ b/sencha-workspace/packages/slate-core-data/src/store/Terms.js
@@ -16,6 +16,9 @@ Ext.define('Slate.store.Terms', {
             }
         },
         sorters: [{
+            property: 'masterStartDate',
+            direction: 'DESC'
+        },{
             property: 'Left',
             direction: 'ASC'
         }]

--- a/sencha-workspace/packages/slate-core-data/src/store/people/Groups.js
+++ b/sencha-workspace/packages/slate-core-data/src/store/people/Groups.js
@@ -22,7 +22,7 @@ Ext.define('Slate.store.people.Groups', {
 
     onProxyLoad: function(operation) {
         var me = this,
-            i = 0, count, group, parentGroup;
+            i = 0, count, group, parentGroup, namesStack;
 
         me.callParent(arguments);
 
@@ -34,7 +34,13 @@ Ext.define('Slate.store.people.Groups', {
         for (count = me.getCount(); i < count; i++) {
             group = me.getAt(i);
             parentGroup = me.getById(group.get('ParentID'));
-            group.set('namesPath', (parentGroup ? parentGroup.get('namesPath') : '') + '/' + group.get('Name'));
+            namesStack = [ group.get('Name') ];
+
+            if (parentGroup) {
+                namesStack = parentGroup.get('namesStack').concat(namesStack);
+            }
+
+            group.set('namesStack', namesStack);
         }
         me.endUpdate();
     }


### PR DESCRIPTION
- feat: default courses browser to current term
- feat: sort terms manager tree by masterStartDate
- feat: sort global terms store by masterStartDate by default
- feat: decorate terms store before load event fires
- feat: start with no nav open to match no manager being loaded
- fix: escape unicode character to survive cmd
- fix: avoid crash when lazy loading chained combo store
- fix: update Groups store to decorate before load fires
- fix: update uses of currentTerm
- fix: handle comboxbox getValue returning an ID
- fix: always use chained store in combobox when valueField isn't ID
- fix: clone namesStack before mutating so isEqual can work
- fix: apply permission-based field visibility after class-based
- fix: load SiteEnvironment data from host page
- fix: improve management of stacked group paths
- fix: support apiSSL param in dev loader
- refactor: consistently preload terms
- chore: add temporary project-all script