### PR TITLE
Release: slate v2.7.8

### DIFF
--- a/.holo/lenses/slate-admin.toml
+++ b/.holo/lenses/slate-admin.toml
@@ -7,10 +7,21 @@ app = "SlateAdmin"
 [hololens.input]
 root = "sencha-workspace"
 files = [
-    "workspace.json",
-    "ext/**",
-    "packages/**",
     "SlateAdmin/**",
+    "packages/slate-theme/**",
+    "packages/slate-core-data/**",
+    "packages/emergence-apikit/**",
+    "packages/jarvus-apikit/**",
+    "packages/jarvus-routing/**",
+    "packages/jarvus-lazydata/**",
+    "packages/jarvus-griderrors/**",
+    "packages/jarvus-ext-actionevents/**",
+    "packages/jarvus-ext-treerecords/**",
+    "packages/jarvus-ext-glyphs/**",
+    "packages/jarvus-ext-searchfield/**",
+    "packages/jarvus-hotfixes/**",
+    "ext/**",
+    "workspace.json",
 ]
 
 [hololens.output]

--- a/php-classes/Slate/Courses/SectionParticipantsRequestHandler.php
+++ b/php-classes/Slate/Courses/SectionParticipantsRequestHandler.php
@@ -20,6 +20,20 @@ class SectionParticipantsRequestHandler extends \Slate\RecordsRequestHandler
         if ($Section = static::getRequestedSection()) {
             $conditions['CourseSectionID'] = $Section->ID;
             $filterObjects['Section'] = $Section;
+        } elseif ($Term = static::getRequestedTerm()) {
+            $courseSectionIds = array_map(function($section) {
+                return $section->ID;
+            }, Section::getAllByWhere(['TermID' => $Term->ID]));
+
+            $conditions['CourseSectionID'] = [
+                'operator' => 'IN',
+                'values' => $courseSectionIds
+            ];
+        }
+
+        if ($Student = static::getRequestedStudent()) {
+            $conditions['PersonID'] = $Student->ID;
+            $filterObjects['Student'] = $Student;
         }
 
         if (!empty($_REQUEST['cohort'])) {

--- a/php-config/Git.config.d/slate.php
+++ b/php-config/Git.config.d/slate.php
@@ -5,6 +5,19 @@ Git::$repositories['slate'] = [
     'originBranch' => 'emergence/vfs-site/v2',
     'workingBranch' => 'emergence/vfs-site/v2',
     'trees' => [
-        '.' => '/'
+        'api-docs',
+        'content-blocks',
+        'data-exporters',
+        'dwoo-plugins',
+        'event-handlers',
+        'html-templates',
+        'php-classes',
+        'php-config',
+        'php-migrations',
+        'phpunit-tests',
+        'site-root',
+        'site-tasks',
+        'webapp-builds',
+        // 'webapp-plugin-builds'
     ]
 ];

--- a/sencha-workspace/SlateAdmin/app/controller/people/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/controller/people/Courses.js
@@ -80,8 +80,8 @@ Ext.define('SlateAdmin.controller.people.Courses', {
 
 
         // configure proxy and load store
-        personSectionsProxy.url = '/people/' + person.get('ID') + '/courses';
-        personSectionsProxy.setExtraParam('termID', selectedTerm || null);
+        personSectionsProxy.setExtraParam('student', person.get('ID'));
+        personSectionsProxy.setExtraParam('term', selectedTerm || null);
         personSectionsStore.load();
     },
 
@@ -90,7 +90,7 @@ Ext.define('SlateAdmin.controller.people.Courses', {
             personSectionsStore = me.getCoursesGrid().getStore(),
             personSectionsProxy = personSectionsStore.getProxy();
 
-        personSectionsProxy.setExtraParam('termID', newValue);
+        personSectionsProxy.setExtraParam('term', newValue);
 
         if (personSectionsProxy.isExtraParamsDirty()) {
             personSectionsStore.load();

--- a/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
@@ -65,13 +65,14 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
                 menuDisabled: true
             },
             items: [{
+                width: 120,
+
                 header: 'Section',
                 dataIndex: 'Code',
-                width: 90,
                 xtype: 'templatecolumn',
                 tpl: '<tpl for="Section"><a href="#course-sections/lookup/{Code}" title="{Title:htmlEncode}">{Code}</a></tpl>'
             },{
-                width: 100,
+                width: 110,
 
                 xtype: 'datecolumn',
                 header: 'Start',
@@ -79,7 +80,7 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
                 format:'Y-m-d',
                 editor: 'datefield'
             },{
-                width: 100,
+                width: 110,
 
                 xtype: 'datecolumn',
                 header: 'End',
@@ -87,14 +88,16 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
                 format:'Y-m-d',
                 editor: 'datefield'
             },{
+                flex: 2,
+
                 header: 'Schedule',
                 dataIndex: 'Schedule',
-                width: 90,
                 xtype: 'templatecolumn',
                 tpl: '<tpl for="Section"><tpl for="Schedule">{Title}</tpl></tpl>'
             },{
+                flex: 2,
+
                 header: 'Location',
-                width: 130,
                 dataIndex: 'Location',
                 xtype: 'templatecolumn',
                 tpl: '<tpl for="Section"><tpl for="Location">{Title}</tpl></tpl>'

--- a/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
@@ -56,6 +56,10 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
                 limitParam: false,
                 pageParam: false
             },
+            sorters: [{
+                property: 'isInactive',
+                direction: 'ASC'
+            }],
             autoSync: true
         },
         columns: {

--- a/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
@@ -6,8 +6,8 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
         'Ext.grid.Panel',
         'Ext.grid.column.Template',
         'Ext.form.field.ComboBox',
-        'SlateAdmin.model.course.Section',
-        'SlateAdmin.proxy.API'
+        'Slate.model.course.SectionParticipant',
+        'Slate.proxy.courses.SectionParticipants'
     ],
 
 
@@ -41,23 +41,20 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
             emptyText: 'No courses for selected term',
             getRowClass: function(record){
                 return record.get('isInactive') === true ? 'participant-inactive' : '';
-                }
+            }
         },
         plugins: {
             ptype: 'cellediting',
             clicksToEdit: 1
         },
         store: {
-            model: 'SlateAdmin.model.course.SectionParticipant',
+            model: 'Slate.model.course.SectionParticipant',
             proxy: {
-                type: 'slaterecords',
+                type: 'slate-courses-participants',
+                include: ['Section.Location', 'Section.Schedule'],
                 startParam: false,
                 limitParam: false,
-                pageParam: false,
-                extraParams: {
-                    include: 'Section.Schedule,Section.Location'
-                },
-                url: '/section-participants'
+                pageParam: false
             },
             autoSync: true
         },

--- a/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
@@ -69,7 +69,7 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
                 dataIndex: 'Code',
                 width: 90,
                 xtype: 'templatecolumn',
-                tpl: '<tpl for="Section"><a href="#course-sections/lookup/{Code}" alt={Title}>{Code}</a></tpl>'
+                tpl: '<tpl for="Section"><a href="#course-sections/lookup/{Code}" title="{Title:htmlEncode}">{Code}</a></tpl>'
             },{
                 width: 100,
 

--- a/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
@@ -40,21 +40,8 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
         viewConfig: {
             emptyText: 'No courses for selected term',
             getRowClass: function(record){
-                const now = new Date();
-                let isActive = true;
-
-                if (record.get('StartDate')) {
-                    let startTime = new Date(Date.parse(record.get('StartDate')));
-                    console.log(startTime, 'start time', now);
-                    isActive = startTime && startTime.getTime() < now.getTime();
+                return record.get('isInactive') === true ? 'participant-inactive' : '';
                 }
-                if (isActive && record.get('EndDate')) {
-                    let endTime = new Date(Date.parse(record.get('EndDate')));
-                    isActive = endTime && endTime.getTime() > now.getTime();
-                }
-
-                return isActive === false ? 'inactive-participant' : 'active-participant';
-            }
         },
         plugins: {
             ptype: 'cellediting',

--- a/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
@@ -51,11 +51,9 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
             model: 'Slate.model.course.SectionParticipant',
             proxy: {
                 type: 'slate-courses-participants',
-                include: ['Section.Location', 'Section.Schedule'],
-                startParam: false,
-                limitParam: false,
-                pageParam: false
+                include: ['Section.Location', 'Section.Schedule']
             },
+            pageSize: 0,
             sorters: [{
                 property: 'isInactive',
                 direction: 'ASC'

--- a/sencha-workspace/SlateAdmin/sass/src/view/people/details/Courses.scss
+++ b/sencha-workspace/SlateAdmin/sass/src/view/people/details/Courses.scss
@@ -1,3 +1,3 @@
-.inactive-participant {
+.participant-inactive {
     opacity: 0.5;
 }

--- a/sencha-workspace/SlateAdmin/sass/src/view/people/details/Courses.scss
+++ b/sencha-workspace/SlateAdmin/sass/src/view/people/details/Courses.scss
@@ -1,0 +1,3 @@
+.inactive-participant {
+    opacity: 0.5;
+}

--- a/sencha-workspace/packages/slate-core-data/src/model/course/SectionParticipant.js
+++ b/sencha-workspace/packages/slate-core-data/src/model/course/SectionParticipant.js
@@ -79,6 +79,20 @@ Ext.define('Slate.model.course.SectionParticipant', {
             calculate: function(data) {
                 return data.PersonFirstName + ' ' + data.PersonLastName;
             }
+        },
+        {
+            name: 'isInactive',
+            persist: false,
+            depends: ['StartDate', 'EndDate'],
+            convert: function(v, rec) {
+                var start = rec.get('StartDate'),
+                    end = rec.get('EndDate');
+
+                return Boolean(
+                    (start && start.getTime() > Date.now()) ||
+                    (end && end.getTime() < Date.now())
+                );
+            }
         }
     ],
 


### PR DESCRIPTION
- feat: add stert/end date columns to person->course
- feat: sort sections, inactive at bottom by default
- fix: update inactive state class name
- fix: disable paging on store instead of just disabling params
- fix: use title attribute for A hover and quote value
- fix: tweak column sizing
- chore: use explicit roots list for legacy git mappings
- refactor: move `isInactive` logic to model
- refactor: use slate-core-data model/proxy
- refactor: minimize sencha app package trees