### PR TITLE
Release: slate v2.7.9

### DIFF
--- a/php-classes/Emergence/Locations/Location.php
+++ b/php-classes/Emergence/Locations/Location.php
@@ -64,7 +64,7 @@ class Location extends \VersionedRecord
     ];
 
 
-    public static function getOrCreateByHandle($handle, $title = null)
+    public static function getOrCreateByHandle($handle, $save = false, $title = null)
     {
         $handle = HandleBehavior::transformText($handle);
 
@@ -74,7 +74,7 @@ class Location extends \VersionedRecord
             return static::create([
                 'Title' => $title ? $title : $handle
                 ,'Handle' => $handle
-            ], true);
+            ], $save);
         }
     }
 

--- a/php-classes/Emergence/Locations/Location.php
+++ b/php-classes/Emergence/Locations/Location.php
@@ -64,17 +64,17 @@ class Location extends \VersionedRecord
     ];
 
 
-    public static function getOrCreateByHandle($handle, $save = false, $title = null)
+    public static function getOrCreateByHandle($handle, $save = false, array $defaults = [])
     {
         $handle = HandleBehavior::transformText($handle);
 
         if ($Location = static::getByHandle($handle)) {
             return $Location;
         } else {
-            return static::create([
-                'Title' => $title ? $title : $handle
-                ,'Handle' => $handle
-            ], $save);
+            return static::create(array_merge($defaults, [
+                'Title' => empty($defaults['Title']) ? $handle : $defaults['Title'],
+                'Handle' => $handle
+            ]), $save);
         }
     }
 

--- a/php-classes/Slate/Connectors/AbstractSpreadsheetConnector.php
+++ b/php-classes/Slate/Connectors/AbstractSpreadsheetConnector.php
@@ -1561,7 +1561,10 @@ class AbstractSpreadsheetConnector extends \Emergence\Connectors\AbstractSpreads
         }
 
         if (!empty($row['Location'])) {
-            $Section->Location = Location::getOrCreateByHandle('room-'.$row['Location'], false, 'Room '.$row['Location']);
+            $Section->Location = Location::getOrCreateByHandle('room-'.$row['Location'], false, [
+                'Title' => 'Room '.$row['Location'],
+                'Parent' => static::$sectionsRootLocation ? Location::getByHandle(static::$sectionsRootLocation) : null
+            ]);
         }
 
         if (!empty($row['StudentsCapacity'])) {

--- a/php-classes/Slate/Connectors/AbstractSpreadsheetConnector.php
+++ b/php-classes/Slate/Connectors/AbstractSpreadsheetConnector.php
@@ -46,10 +46,12 @@ class AbstractSpreadsheetConnector extends \Emergence\Connectors\AbstractSpreads
     public static $teachersRootGroup = 'teachers';
     public static $parentsRootGroup = 'parents';
 
-
     // section referencing
     public static $sectionCodeReferences = false;
     public static $sectionMappingReferences = true;
+
+    // location assignments
+    public static $sectionsRootLocation = null;
 
     // workflow callable overrides
     public static $sectionTitleFormatter;
@@ -1559,7 +1561,7 @@ class AbstractSpreadsheetConnector extends \Emergence\Connectors\AbstractSpreads
         }
 
         if (!empty($row['Location'])) {
-            $Section->Location = Location::getOrCreateByHandle('room-'.$row['Location'], 'Room '.$row['Location']);
+            $Section->Location = Location::getOrCreateByHandle('room-'.$row['Location'], false, 'Room '.$row['Location']);
         }
 
         if (!empty($row['StudentsCapacity'])) {

--- a/php-classes/Slate/Courses/SectionParticipantsRequestHandler.php
+++ b/php-classes/Slate/Courses/SectionParticipantsRequestHandler.php
@@ -23,7 +23,12 @@ class SectionParticipantsRequestHandler extends \Slate\RecordsRequestHandler
         } elseif ($Term = static::getRequestedTerm()) {
             $courseSectionIds = array_map(function($section) {
                 return $section->ID;
-            }, Section::getAllByWhere(['TermID' => $Term->ID]));
+            }, Section::getAllByWhere([
+                'TermID' => [
+                    'operator' => 'IN',
+                    'values' => $Term->getContainedTermIDs()
+                ]
+            ]));
 
             $conditions['CourseSectionID'] = [
                 'operator' => 'IN',

--- a/php-classes/Slate/Term.php
+++ b/php-classes/Slate/Term.php
@@ -158,7 +158,7 @@ class Term extends \VersionedRecord
         return static::getAllByWhere('ParentID IS NULL', ['order' => 'StartDate DESC']);
     }
 
-    public static function getOrCreateByHandle($handle)
+    public static function getOrCreateByHandle($handle, $save = false)
     {
         if ($Term = static::getByHandle($handle)) {
             return $Term;
@@ -166,7 +166,7 @@ class Term extends \VersionedRecord
             return static::create([
                 'Title' => $handle
                 ,'Handle' => $handle
-            ], true);
+            ], $save);
         }
     }
 

--- a/php-classes/Slate/TermsRequestHandler.php
+++ b/php-classes/Slate/TermsRequestHandler.php
@@ -36,6 +36,7 @@ class TermsRequestHandler extends \RecordsRequestHandler
             $reportingTerm = Term::getCurrentReporting();
 
             $responseData['currentTerm'] = $currentTerm ? $currentTerm->ID : null;
+            $responseData['currentMasterTerm'] = $currentTerm ? $currentTerm->getMaster()->ID : null;
             $responseData['reportingTerm'] = $reportingTerm ? $reportingTerm->ID : null;
         }
 

--- a/php-config/RemoteSystems/Canvas.config.php
+++ b/php-config/RemoteSystems/Canvas.config.php
@@ -1,5 +1,0 @@
-<?php
-
-#RemoteSystems\Canvas::$canvasHost = 'slatedemo.instructure.com';
-#RemoteSystems\Canvas::$apiToken = 'YOUR_API_TOKEN_HERE';
-#RemoteSystems\Canvas::$accountID = 1;

--- a/sencha-workspace/SlateAdmin/app/controller/people/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/controller/people/Courses.js
@@ -69,7 +69,7 @@ Ext.define('SlateAdmin.controller.people.Courses', {
 
         if (
             !selectedTerm
-            && (selectedTerm = termsStore.getCurrentTerm())
+            && (selectedTerm = termsStore.getCurrentMasterTerm())
         ) {
             // push selected term to combo
             termSelector.setSelection(selectedTerm);

--- a/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/details/Courses.js
@@ -51,7 +51,7 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
             model: 'Slate.model.course.SectionParticipant',
             proxy: {
                 type: 'slate-courses-participants',
-                include: ['Section.Location', 'Section.Schedule']
+                include: ['Section.Location', 'Section.Schedule', 'Section.Term']
             },
             pageSize: 0,
             sorters: [{
@@ -87,6 +87,13 @@ Ext.define('SlateAdmin.view.people.details.Courses', {
                 dataIndex: 'EndDate',
                 format:'Y-m-d',
                 editor: 'datefield'
+            },{
+                flex: 2,
+
+                header: 'Term',
+                dataIndex: 'Term',
+                xtype: 'templatecolumn',
+                tpl: '<tpl for="Section"><tpl for="Term">{Handle}</tpl></tpl>'
             },{
                 flex: 2,
 

--- a/sencha-workspace/SlateAdmin/app/view/settings/terms/Manager.js
+++ b/sencha-workspace/SlateAdmin/app/view/settings/terms/Manager.js
@@ -40,6 +40,12 @@ Ext.define('SlateAdmin.view.settings.terms.Manager', {
             xtype: 'textfield'
         }
     },{
+        text: 'masterStartDate',
+        xtype: 'datecolumn',
+        format :'Y-m-d',
+        width: 160,
+        dataIndex: 'masterStartDate'
+    },{
         text: 'Start Date',
         xtype: 'datecolumn',
         format :'Y-m-d',

--- a/sencha-workspace/packages/slate-core-data/src/store/Terms.js
+++ b/sencha-workspace/packages/slate-core-data/src/store/Terms.js
@@ -6,6 +6,7 @@ Ext.define('Slate.store.Terms', {
 
     config: {
         currentTerm: null,
+        currentMasterTerm: null,
         reportingTerm: null,
 
         pageSize: 0,
@@ -32,6 +33,14 @@ Ext.define('Slate.store.Terms', {
 
     updateCurrentTerm: function (newValue, oldValue) {
         this.fireEvent('currenttermchange', this, newValue, oldValue);
+    },
+
+    applyCurrentMasterTerm: function (value) {
+        return (typeof value == 'number' ? this.getById(value) : value) || null;
+    },
+
+    updateCurrentMasterTerm: function (newValue, oldValue) {
+        this.fireEvent('currentmastertermchange', this, newValue, oldValue);
     },
 
     applyReportingTerm:  function (value) {
@@ -61,6 +70,10 @@ Ext.define('Slate.store.Terms', {
             if (rawData) {
                 if ('currentTerm' in rawData) {
                     me.setCurrentTerm(byId[rawData.currentTerm]);
+                }
+
+                if ('currentMasterTerm' in rawData) {
+                    me.setCurrentMasterTerm(byId[rawData.currentMasterTerm]);
                 }
 
                 if ('reportingTerm' in rawData) {


### PR DESCRIPTION
- feat: use current master term as default for student courses list
- feat: include sub-terms in enrollments filter
- feat: show term in student courses list
- refactor!: accept $save param so locations don't need to be saved during pretend import
- refactor!: add save param to Term getOrCreateByHandle method
- refactor!: accept any fields in place of just title for getOrCreateByHandle defaults
- refactor: merge canvas config example to connector-canvas repo