### PR TITLE
Release: slate v2.7.12

### DIFF
--- a/.github/workflows/holo.yml
+++ b/.github/workflows/holo.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v2.*'
-  schedule:
-    - cron: '0 * * * *'
 
 
 jobs:

--- a/.github/workflows/holo.yml
+++ b/.github/workflows/holo.yml
@@ -28,3 +28,22 @@ jobs:
         ref: releases/v2
         holobranch: emergence-vfs-site
         commit-to: emergence/vfs-site/v2
+    - name: 'Update v2.slate.is'
+      env:
+        VFS_DEV_TOKEN: ${{ secrets.VFS_DEV_TOKEN }}
+      run: |
+        # pull latest commit
+        curl -X POST \
+          --silent \
+          -H "Authorization: Token ${VFS_DEV_TOKEN}" \
+          -H "Accept: application/json" \
+          "http://v2.slate.is/site-admin/sources/slate/pull" \
+          | jq '.'
+
+        # sync VFS to git
+        curl -X POST \
+          --silent \
+          -H "Authorization: Token ${VFS_DEV_TOKEN}" \
+          -H "Accept: application/json" \
+          "http://v2.slate.is/site-admin/sources/slate/sync-to-vfs" \
+          | jq '.'

--- a/.holo/branches/emergence-layer/_slate.toml
+++ b/.holo/branches/emergence-layer/_slate.toml
@@ -1,6 +1,7 @@
 [holomapping]
 files = [
     "*/**",
+    "!.github/",
     "!.vscode/",
     "!docs/",
 


### PR DESCRIPTION
- feat: automate pulling projection output to v2.slate.is
- fix: exclude .github/ from projections
- chore: remove scheduled run of projection workflow