### PR TITLE
fix: hide inactive participants by default

### DIFF
--- a/html-templates/progress/section-interim-reports/_body.email.tpl
+++ b/html-templates/progress/section-interim-reports/_body.email.tpl
@@ -7,10 +7,10 @@
 
 {block teachers}
     <div style="margin: 1em 0;">
-        <span style="color: #5e6366; font-size: smaller; font-style: italic;">Teacher{tif count($Section->Teachers) != 1 ? s}</span>
+        <span style="color: #5e6366; font-size: smaller; font-style: italic;">Teacher{tif count($Section->ActiveTeachers) != 1 ? s}</span>
         <br />
         <span style="display: block; margin-left: 1.5em;">
-            {foreach item=Teacher from=$Section->Teachers implode='<br />'}
+            {foreach item=Teacher from=$Section->ActiveTeachers implode='<br />'}
                 <strong>{$Teacher->FullName|escape}</strong>
                 &lt;<a href="mailto:{$Teacher->Email|escape}?subject=Re:%20{$subject|escape:url}" style="color: #a35500;">{$Teacher->Email|escape}</a>&gt;
             {/foreach}

--- a/html-templates/progress/section-interim-reports/_body.tpl
+++ b/html-templates/progress/section-interim-reports/_body.tpl
@@ -17,12 +17,12 @@
 
 <dl class="item-body">
     {block teachers}
-        {if count($Report->Section->Teachers) && !(count($Report->Section->Teachers) == 1 && $Report->Section->Teachers[0]->ID == $Report->getAuthor()->ID)}
+        {if count($Report->Section->ActiveTeachers) && !(count($Report->Section->ActiveTeachers) == 1 && $Report->Section->ActiveTeachers[0]->ID == $Report->getAuthor()->ID)}
             <div class="dli">
-                <dt class="instructor">Teacher{tif count($Report->Section->Teachers) != 1 ? s}</dt>
+                <dt class="instructor">Teacher{tif count($Report->Section->ActiveTeachers) != 1 ? s}</dt>
                 <dd class="instructor">
                     <ul>
-                        {foreach item=Teacher from=$Report->Section->Teachers}
+                        {foreach item=Teacher from=$Report->Section->ActiveTeachers}
                                 <li>
                                     <span class="instructor-name">{$Teacher->FullName|escape}</span>
                                     <span class="instructor-email"><a href="mailto:{$Teacher->Email|escape}">{$Teacher->Email|escape}</a></span>

--- a/html-templates/progress/section-term-reports/_body.email.tpl
+++ b/html-templates/progress/section-term-reports/_body.email.tpl
@@ -7,10 +7,10 @@
 
 {block teachers}
     <div style="margin: 1em 0;">
-        <span style="color: #5e6366; font-size: smaller; font-style: italic;">Teacher{tif count($Section->Teachers) != 1 ? s}</span>
+        <span style="color: #5e6366; font-size: smaller; font-style: italic;">Teacher{tif count($Section->ActiveTeachers) != 1 ? s}</span>
         <br />
         <span style="display: block; margin-left: 1.5em;">
-            {foreach item=Teacher from=$Section->Teachers implode='<br />'}
+            {foreach item=Teacher from=$Section->ActiveTeachers implode='<br />'}
                 <strong>{$Teacher->FullName|escape}</strong>
                 &lt;<a href="mailto:{$Teacher->Email|escape}?subject=Re:%20{$subject|escape:url}" style="color: #a35500;">{$Teacher->Email|escape}</a>&gt;
             {/foreach}

--- a/html-templates/progress/section-term-reports/_body.tpl
+++ b/html-templates/progress/section-term-reports/_body.tpl
@@ -18,12 +18,12 @@
 
 <dl class="item-body">
     {block teachers}
-        {if $.get.print.teachers != 'no' && count($Report->Section->Teachers) && !(count($Report->Section->Teachers) == 1 && $Report->Section->Teachers[0]->ID == $Report->getAuthor()->ID)}
+        {if $.get.print.teachers != 'no' && count($Report->Section->ActiveTeachers) && !(count($Report->Section->ActiveTeachers) == 1 && $Report->Section->ActiveTeachers[0]->ID == $Report->getAuthor()->ID)}
             <div class="dli">
-                <dt class="instructor">Teacher{tif count($Report->Section->Teachers) != 1 ? s}</dt>
+                <dt class="instructor">Teacher{tif count($Report->Section->ActiveTeachers) != 1 ? s}</dt>
                 <dd class="instructor">
                     <ul>
-                        {foreach item=Teacher from=$Report->Section->Teachers}
+                        {foreach item=Teacher from=$Report->Section->ActiveTeachers}
                                 <li>
                                     <span class="instructor-name">{$Teacher->FullName|escape}</span>
                                     <span class="instructor-email"><a href="mailto:{$Teacher->Email|escape}">{$Teacher->Email|escape}</a></span>

--- a/html-templates/sections/courseSection.tpl
+++ b/html-templates/sections/courseSection.tpl
@@ -41,7 +41,7 @@
 
         $sectionTeacherIds = array_map(function($Teacher) {
             return $Teacher->ID;
-        }, $this->scope['Section']->Teachers);
+        }, $this->scope['Section']->ActiveTeachers);
 
         $latestTeacherPost = \Emergence\CMS\BlogPost::getAllPublishedByContextObject($this->scope['Section'], array_merge_recursive($options, [
             'conditions' => [
@@ -157,9 +157,9 @@
                     </div>
                 {/foreach}
 
-                <h3>Teacher{tif count($Section->Teachers) != 1 ? s}</h3>
+                <h3>Teacher{tif count($Section->ActiveTeachers) != 1 ? s}</h3>
                 <ul class="roster teachers">
-                {foreach item=Teacher from=$Section->Teachers}
+                {foreach item=Teacher from=$Section->ActiveTeachers}
                     <li>{personLink $Teacher photo=true}</li>
                 {foreachelse}
                     <p class="empty-text">No instructors currently listed.</p>
@@ -169,7 +169,7 @@
                 {if $.User}
                     <h3>Students</h3>
                     <ul class="roster students">
-                    {foreach item=Student from=$Section->Students}
+                    {foreach item=Student from=$Section->ActiveStudents}
                         <li>{personLink $Student photo=true}</li>
                     {foreachelse}
                         <p class="empty-text">No students currently listed.</p>

--- a/html-templates/sections/courseSections.tpl
+++ b/html-templates/sections/courseSections.tpl
@@ -71,8 +71,8 @@
             {foreach item=Section from=$group.sections}
                 <tr>
                     <td><a href="{$Section->getURL()}">{$Section->Code}</a></td>
-                    <td>{foreach item=Teacher from=$Section->Teachers implode=', '}{personLink $Teacher}{/foreach}</td>
-                    <td>{$Section->Students|count}</td>
+                    <td>{foreach item=Teacher from=$Section->ActiveTeachers implode=', '}{personLink $Teacher}{/foreach}</td>
+                    <td>{$Section->ActiveStudents|count}</td>
                     <td>{$Section->Location->Title|escape}</td>
                     <td>{$Section->Schedule->Title|escape}</td>
                 </tr>

--- a/php-classes/Slate/Courses/Section.php
+++ b/php-classes/Slate/Courses/Section.php
@@ -141,6 +141,18 @@ class Section extends \VersionedRecord
             ,'foreign' => 'CourseSectionID'
             ,'order' => 'Role DESC, (SELECT CONCAT(LastName,FirstName) FROM people WHERE people.id = PersonID)'
         ]
+        ,'ActiveTeachers' => [
+            'type' => 'many-many'
+            ,'class' => Person::class
+            ,'linkClass' => SectionParticipant::class
+            ,'linkLocal' => 'CourseSectionID'
+            ,'linkForeign' => 'PersonID'
+            ,'conditions' => [
+                'Link.Role = "Teacher"',
+                '(Link.StartDate IS NULL OR DATE(Link.StartDate) <= CURRENT_DATE)',
+                '(Link.EndDate IS NULL OR DATE(Link.EndDate) >= CURRENT_DATE)'
+            ]
+        ]
         ,'Teachers' => [
             'type' => 'many-many'
             ,'class' => Person::class
@@ -148,6 +160,18 @@ class Section extends \VersionedRecord
             ,'linkLocal' => 'CourseSectionID'
             ,'linkForeign' => 'PersonID'
             ,'conditions' => ['Link.Role = "Teacher"']
+        ]
+        ,'ActiveStudents' => [
+            'type' => 'many-many'
+            ,'class' => Person::class
+            ,'linkClass' => SectionParticipant::class
+            ,'linkLocal' => 'CourseSectionID'
+            ,'linkForeign' => 'PersonID'
+            ,'conditions' => [
+                'Link.Role = "Student"',
+                '(Link.StartDate IS NULL OR DATE(Link.StartDate) <= CURRENT_DATE)',
+                '(Link.EndDate IS NULL OR DATE(Link.EndDate) >= CURRENT_DATE)'
+            ]
         ]
         ,'Students' => [
             'type' => 'many-many'

--- a/php-classes/Slate/Courses/SectionsRequestHandler.php
+++ b/php-classes/Slate/Courses/SectionsRequestHandler.php
@@ -143,8 +143,10 @@ class SectionsRequestHandler extends \Slate\RecordsRequestHandler
             } catch (\TableNotFoundException $e) {
                 $students = [];
             }
-        } else {
+        } elseif (!empty($_REQUEST['inactive'])) {
             $students = $Section->Students;
+        } else {
+            $students = $Section->ActiveStudents;
         }
 
         return static::respond('students', [


### PR DESCRIPTION
This PR adds a relationship to `Slate\Courses\Section` for "Active" teachers and students within a section, and replaces areas in the UI that show all teachers and students, to show only active teachers and students by default.

Active is defined by participants with StartDate <= Current Date <= EndDate