### PR TITLE
Release: slate v2.8.4

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
     "env": {
-        "browser": true
+        "browser": true,
+        "es6": true
     },
     "globals": {
         "Ext": true

--- a/data-exporters/slate/interims.php
+++ b/data-exporters/slate/interims.php
@@ -1,0 +1,98 @@
+<?php
+
+use Slate\Term;
+use Slate\Progress\SectionInterimReport;
+
+return [
+    'title' => 'Interim Reports',
+    'description' => 'Each row represents an interim report for a given student+section+term',
+    'filename' => 'interim-reports',
+    'headers' => [
+        'ReportID' => 'Report ID',
+        'ReportDate' => 'Report Date',
+        'StudentName' => 'Student Name',
+        'StudentID' => 'Student ID',
+        'StudentYear' => 'Student Year',
+        'StudentGradeLevel' => 'Student Grade Level',
+        'StudentAdvisor' => 'Student Advisor',
+        'InterimSection' => 'Interim Section',
+        'InterimAuthor' => 'Interim Author',
+        'InterimGrade' => 'Interim Grade'
+    ],
+    'readQuery' => function (array $input) {
+        $query = [
+            'term' => null
+        ];
+
+        if (!empty($input['term'])) {
+            if ($input['term'] == '*current') {
+                if (!$Term = Term::getClosest()) {
+                    throw new OutOfBoundsException('no current term found');
+                }
+            } elseif (!$Term = Term::getByHandle($input['term'])) {
+                throw new OutOfBoundsException('term not found');
+            }
+
+            $query['term'] = $Term->Handle;
+        }
+
+        return $query;
+    },
+    'buildRows' => function (array $query = [], array $config = []) {
+
+        // calculate closest graduation year for converting year to grade
+        $closestGraduationYear = Term::getClosestGraduationYear();
+
+        // build conditions
+        $conditions = [];
+        $order = [
+            'ID'
+        ];
+
+        if ($query['term']) {
+            $conditions['TermID'] = [
+                'values' => Term::getByHandle($query['term'])->getRelatedTermIDs()
+            ];
+        }
+
+        $conditions = SectionInterimReport::mapConditions($conditions);
+
+        // build rows
+        try {
+            $result = DB::query(
+                '
+                    SELECT Report.*
+                      FROM `%s` Report
+                     WHERE (%s)
+                     ORDER BY %s
+                ',
+                [
+                    SectionInterimReport::$tableName,
+                    count($conditions) ? join(') AND (', $conditions) : 'TRUE',
+                    implode(',', $order)
+                ]
+            );
+
+            while ($record = $result->fetch_assoc()) {
+                $Report = SectionInterimReport::instantiateRecord($record);
+
+                yield [
+                    'ReportID' => $Report->ID,
+                    'ReportDate' => date('Y-m-d H:i', $Report->Created),
+                    'StudentName' => $Report->Student->LastName.', '.$Report->Student->FirstName,
+                    'StudentID' => $Report->Student->StudentNumber,
+                    'StudentYear' => $Report->Student->GraduationYear,
+                    'StudentGradeLevel' => 12 - ($Report->Student->GraduationYear - $closestGraduationYear),
+                    'StudentAdvisor' => $Report->Student->Advisor->LastName.', '.$Report->Student->Advisor->FirstName,
+                    'InterimSection' => $Report->Section->Code,
+                    'InterimAuthor' => $Report->Creator->LastName.', '.$Report->Creator->FirstName,
+                    'InterimGrade' => $Report->Grade
+                ];
+            }
+        } finally {
+            if ($result) {
+                $result->free();
+            }
+        }
+    }
+];

--- a/html-templates/exports/exports.tpl
+++ b/html-templates/exports/exports.tpl
@@ -1,6 +1,8 @@
 {extends designs/site.tpl}
 
 {block content}
+    {load_templates "subtemplates/slate-forms.tpl"}
+
     {foreach key=scriptPath item=script from=$scripts implode="<hr>"}
         <h2>{$script.title|escape}</h2>
 
@@ -19,6 +21,35 @@
                         default=$value
                         placeholder='123,345'
                         hint='List of student IDs, group:grouphandle, or section:sectioncode, or all'
+                    }
+                {elseif $key == 'term'}
+                    {termField
+                        inputName=$key
+                        label=$label
+                        default=$value
+                        blankOption='any'
+                        currentOption='current'
+                    }
+                {elseif $key == 'course'}
+                    {courseField
+                        inputName=$key
+                        label=$label
+                        default=$value
+                        blankOption='any'
+                    }
+                {elseif $key == 'location'}
+                    {locationField
+                        inputName=$key
+                        label=$label
+                        default=$value
+                        blankOption='any'
+                    }
+                {elseif $key == 'schedule'}
+                    {scheduleField
+                        inputName=$key
+                        label=$label
+                        default=$value
+                        blankOption='any'
                     }
                 {elseif is_bool($value)}
                     {checkbox

--- a/html-templates/subtemplates/slate-forms.tpl
+++ b/html-templates/subtemplates/slate-forms.tpl
@@ -19,7 +19,7 @@
         label=$label
         blankOption=$blankOption
         blankValue=$blankValue
-        default=$default->Handle
+        default=tif(is_string($default) ? $default : $default->Handle)
         error=$error
         hint=$hint
         required=$required
@@ -41,7 +41,7 @@
         label=$label
         blankOption=$blankOption
         blankValue=$blankValue
-        default=$default->Code
+        default=tif(is_string($default) ? $default : $default->Code)
         error=$error
         hint=$hint
         required=$required
@@ -63,7 +63,7 @@
         label=$label
         blankOption=$blankOption
         blankValue=$blankValue
-        default=$default->Handle
+        default=tif(is_string($default) ? $default : $default->Handle)
         error=$error
         hint=$hint
         required=$required
@@ -85,7 +85,7 @@
         label=$label
         blankOption=$blankOption
         blankValue=$blankValue
-        default=$default->Handle
+        default=tif(is_string($default) ? $default : $default->Handle)
         error=$error
         hint=$hint
         required=$required

--- a/php-classes/Slate/UI/Adapters/ManageSlate.php
+++ b/php-classes/Slate/UI/Adapters/ManageSlate.php
@@ -9,15 +9,15 @@ class ManageSlate implements \Slate\UI\ILinksSource
     public static $parentTree = 'Tools';
     public static $icon = 'tools';
 
-    public static $people = true;
-    public static $courseSections = true;
-    public static $schoolSettings = true;
-    public static $pages = true;
+    public static $people = 1000;
+    public static $courseSections = 1100;
+    public static $schoolSettings = 1200;
+    public static $pages = 1300;
 
     public static function getLinks($context = null)
     {
         $manageLinks = static::getManageLinks();
-        
+
         if (empty($manageLinks)) {
             return null;
         }
@@ -37,31 +37,35 @@ class ManageSlate implements \Slate\UI\ILinksSource
             '_weight' => static::$weight
         ];
 
-        if (static::$people) {
+        if (is_int(static::$people)) {
             $menu['People'] = [
                 '_href' => '/manage#people',
-                '_icon' => 'users'
+                '_icon' => 'users',
+                '_weight' => static::$people
             ];
         }
 
-        if (static::$courseSections) {
+        if (is_int(static::$courseSections)) {
             $menu['Course Sections'] = [
                 '_href' => '/manage#course-sections',
-                '_icon' => 'books'
+                '_icon' => 'books',
+                '_weight' => static::$courseSections
             ];
         }
 
-        if (static::$schoolSettings) {
+        if (is_int(static::$schoolSettings)) {
             $menu['School Settings'] = [
                 '_href' => '/manage#settings',
-                '_icon' => 'gears'
+                '_icon' => 'gears',
+                '_weight' => static::$schoolSettings
             ];
         }
 
-        if (static::$pages) {
+        if (is_int(static::$pages)) {
             $menu['Pages'] = [
                 '_href' => '/pages',
-                '_icon' => 'records'
+                '_icon' => 'records',
+                '_weight' => static::$pages
             ];
         }
 

--- a/php-classes/Slate/UI/Adapters/ManageSlate.php
+++ b/php-classes/Slate/UI/Adapters/ManageSlate.php
@@ -13,6 +13,7 @@ class ManageSlate implements \Slate\UI\ILinksSource
     public static $courseSections = 1100;
     public static $schoolSettings = 1200;
     public static $pages = 1300;
+    public static $exports = 10000;
 
     public static function getLinks($context = null)
     {
@@ -66,6 +67,14 @@ class ManageSlate implements \Slate\UI\ILinksSource
                 '_href' => '/pages',
                 '_icon' => 'records',
                 '_weight' => static::$pages
+            ];
+        }
+
+        if (is_int(static::$exports)) {
+            $menu['Exports'] = [
+                '_icon' => 'export',
+                '_href' => '/exports',
+                '_weight' => static::$exports
             ];
         }
 

--- a/php-classes/Slate/UI/LinkUtil.php
+++ b/php-classes/Slate/UI/LinkUtil.php
@@ -68,7 +68,7 @@ class LinkUtil
                 throw new \UnexpectedValueException('Link tree value must be array, string, or ActiveRecord instance');
             }
 
-            
+
             // apply dynamically-derived attributes
             if (!empty($value['_tag'])) {
                 $children = [];
@@ -140,6 +140,7 @@ class LinkUtil
             // copy normalized children to link
             if (count($children)) {
                 $link['children'] = static::normalizeTree($children, $context);
+                uasort($link['children'], [static::class, 'sortLinks']);
             }
 
             // apply weight

--- a/sencha-workspace/SlateAdmin/app/view/courses/sections/details/Participants.js
+++ b/sencha-workspace/SlateAdmin/app/view/courses/sections/details/Participants.js
@@ -114,7 +114,8 @@ Ext.define('SlateAdmin.view.courses.sections.details.Participants', {
                 }
             },{
                 xtype: 'actioncolumn',
-                width: 40,
+                width: 50, // n*15+20
+                align: 'end',
                 items: [{
                     action: 'open',
                     iconCls: 'participant-open glyph-primary',

--- a/sencha-workspace/SlateAdmin/app/view/groups/Manager.js
+++ b/sencha-workspace/SlateAdmin/app/view/groups/Manager.js
@@ -26,6 +26,10 @@ Ext.define('SlateAdmin.view.groups.Manager', {
             xtype: 'textfield'
         }
     },{
+        text: 'namesPath',
+        dataIndex: 'namesPath',
+        flex: 4
+    },{
         text: 'Code',
         width: 200,
         dataIndex: 'Handle',
@@ -59,7 +63,8 @@ Ext.define('SlateAdmin.view.groups.Manager', {
     },{
         xtype: 'actioncolumn',
         dataIndex: 'Class',
-        width: 80,
+        width: 65, // n*15+20
+        align: 'end',
         items: [
             {
                 action: 'browsemembers',

--- a/sencha-workspace/SlateAdmin/app/view/people/details/Contacts.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/details/Contacts.js
@@ -169,7 +169,8 @@ Ext.define('SlateAdmin.view.people.details.Contacts', {
                 {
                     xtype: 'actioncolumn',
                     dataIndex: 'Class',
-                    width: 54,
+                    width: 50, // n*15+20
+                    align: 'end',
                     items: [
                         {
                             action: 'delete',
@@ -417,7 +418,8 @@ Ext.define('SlateAdmin.view.people.details.Contacts', {
             {
                 xtype: 'actioncolumn',
                 dataIndex: 'Primary',
-                width: 36,
+                width: 50, // n*15+20
+                align: 'end',
                 items: [
                     {
                         action: 'delete',

--- a/sencha-workspace/SlateAdmin/app/view/settings/courses/Manager.js
+++ b/sencha-workspace/SlateAdmin/app/view/settings/courses/Manager.js
@@ -42,7 +42,8 @@ Ext.define('SlateAdmin.view.settings.courses.Manager', {
     },{
         xtype: 'actioncolumn',
         dataIndex: 'Class',
-        width: 80,
+        width: 50, // n*15+20
+        align: 'end',
         items: [
             {
                 action: 'browsecourses',

--- a/sencha-workspace/SlateAdmin/app/view/settings/departments/Manager.js
+++ b/sencha-workspace/SlateAdmin/app/view/settings/departments/Manager.js
@@ -42,7 +42,8 @@ Ext.define('SlateAdmin.view.settings.departments.Manager', {
     },{
         xtype: 'actioncolumn',
         dataIndex: 'Class',
-        width: 80,
+        width: 50, // n*15+20
+        align: 'end',
         items: [
             {
                 action: 'browsecourses',

--- a/sencha-workspace/SlateAdmin/app/view/settings/globalrecipients/Manager.js
+++ b/sencha-workspace/SlateAdmin/app/view/settings/globalrecipients/Manager.js
@@ -36,7 +36,8 @@ Ext.define('SlateAdmin.view.settings.globalrecipients.Manager', {
     },{
         xtype: 'actioncolumn',
         dataIndex: 'Class',
-        width: 80,
+        width: 50, // n*15+20
+        align: 'end',
         items: [
             {
                 action: 'view',

--- a/sencha-workspace/SlateAdmin/app/view/settings/locations/Manager.js
+++ b/sencha-workspace/SlateAdmin/app/view/settings/locations/Manager.js
@@ -48,7 +48,8 @@ Ext.define('SlateAdmin.view.settings.locations.Manager', {
     },{
         xtype: 'actioncolumn',
         dataIndex: 'Class',
-        width: 80,
+        width: 65, // n*15+20
+        align: 'end',
         items: [
             {
                 action: 'browsecourses',

--- a/sencha-workspace/SlateAdmin/app/view/settings/terms/Manager.js
+++ b/sencha-workspace/SlateAdmin/app/view/settings/terms/Manager.js
@@ -84,7 +84,8 @@ Ext.define('SlateAdmin.view.settings.terms.Manager', {
     },{
         xtype: 'actioncolumn',
         dataIndex: 'Class',
-        width: 80,
+        width: 65, // n*15+20
+        align: 'end',
         items: [
             {
                 action: 'browsecourses',

--- a/sencha-workspace/packages/slate-core-data/src/store/people/Advisors.js
+++ b/sencha-workspace/packages/slate-core-data/src/store/people/Advisors.js
@@ -1,27 +1,11 @@
 Ext.define('Slate.store.people.Advisors', {
-    extend: 'Ext.data.Store',
-    requires: [
-        'Slate.proxy.Records'
-    ],
+    extend: 'Slate.store.people.People',
 
-
-    model: 'Slate.model.person.Person',
 
     config: {
-        pageSize: false,
         proxy: {
-            type: 'slate-records',
+            type: 'slate-people',
             url: '/people/*advisors'
-        },
-        sorters: [
-            {
-                property: 'LastName',
-                direction: 'ASC'
-            },
-            {
-                property: 'FirstName',
-                direction: 'ASC'
-            }
-        ]
+        }
     }
 });

--- a/sencha-workspace/packages/slate-core-data/src/store/people/People.js
+++ b/sencha-workspace/packages/slate-core-data/src/store/people/People.js
@@ -1,0 +1,37 @@
+Ext.define('Slate.store.people.People', {
+    extend: 'Ext.data.Store',
+
+
+    model: 'Slate.model.person.Person',
+    config: {
+        pageSize: 0,
+        remoteSort: false,
+        sorters: [{
+            property: 'SortName',
+            direction: 'ASC'
+        }],
+        proxy: 'slate-people'
+    },
+
+
+    constructor: function() {
+        this.callParent(arguments);
+        this.dirty = true;
+    },
+
+
+    // member methods
+    loadIfDirty: function() {
+        if (!this.dirty) {
+            return;
+        }
+
+        this.dirty = false;
+        this.load();
+    },
+
+    unload: function() {
+        this.loadCount = 0;
+        this.removeAll();
+    }
+});

--- a/sencha-workspace/packages/slate-core-data/src/store/people/Students.js
+++ b/sencha-workspace/packages/slate-core-data/src/store/people/Students.js
@@ -1,17 +1,10 @@
 Ext.define('Slate.store.people.Students', {
-    extend: 'Ext.data.Store',
+    extend: 'Slate.store.people.People',
 
 
-    model: 'Slate.model.person.Person',
     config: {
         list: null,
 
-        pageSize: 0,
-        remoteSort: false,
-        sorters: [{
-            property: 'SortName',
-            direction: 'ASC'
-        }],
         proxy: {
             type: 'slate-people',
             url: '/people/*students',
@@ -20,31 +13,9 @@ Ext.define('Slate.store.people.Students', {
     },
 
 
-    constructor: function() {
-        this.callParent(arguments);
-        this.dirty = true;
-    },
-
-
     // config handlers
     updateList: function(list) {
         this.getProxy().setExtraParam('list', list || null);
         this.dirty = true;
-    },
-
-
-    // member methods
-    loadIfDirty: function() {
-        if (!this.dirty) {
-            return;
-        }
-
-        this.dirty = false;
-        this.load();
-    },
-
-    unload: function() {
-        this.loadCount = 0;
-        this.removeAll();
     }
 });

--- a/site-root/sass/slate/modules/_events.scss
+++ b/site-root/sass/slate/modules/_events.scss
@@ -1,6 +1,6 @@
 .event-day {
     margin: 2.5em 0;
-    
+
     &:first-child {
         margin-top: 1em;
     }
@@ -14,27 +14,35 @@
 }
 
 .vevent {
-	background: url(/img/icons/fugue/calendar.png) no-repeat;
 	font-size: .95em;
 	line-height: 1.3;
 	margin-bottom: .6em;
+	position: relative;
+
+	&:before {
+		content: '\f133'; // fa-calendar
+		font-family: FontAwesome;
+		position: absolute;
+		top: 0;
+		left: 0;
+	}
 
 	a {
 		color: inherit;
 		display: inline-block;
 		padding-left: 24px;
 		text-decoration: none;
-		
+
 		&:hover {
     		color: $link-color;
 		}
 	}
-	
+
 	.summary,
 	.contact {
 		display: block;
 	}
-	
+
 	.meta-info {
 	    color: $muted-color;
 		font-size: .9em;
@@ -49,7 +57,7 @@
         font-size: large;
         margin: 0;
     }
-    
+
     .event-times {
         color: $muted-color;
     }


### PR DESCRIPTION
- feat: add term/course/location/schedule exporter fields
- feat: add interims exporter
- feat: add exports to management tools
- feat: enable string defaults for selectField wrappers
- feat: merge improved interim exporter
- fix: normalize actioncolumn width/alignment
- fix: sort child links by weight
- fix: set explicit weights on management tools
- fix: replace missing fugue calendar icon with fontawesome
- refactor: add core people store
- chore: enable es6 globals for eslint