### PR TITLE
Release: slate v2.9.3

### DIFF
--- a/.holo/branches/extjs-theme/_slate.toml
+++ b/.holo/branches/extjs-theme/_slate.toml
@@ -1,3 +1,3 @@
 [holomapping]
-root = "sencha-workspace/packages/slate-core-data"
+root = "sencha-workspace/packages/slate-theme"
 files = "**"

--- a/.holo/branches/extjs-ui-classic/_slate.toml
+++ b/.holo/branches/extjs-ui-classic/_slate.toml
@@ -1,3 +1,3 @@
 [holomapping]
-root = "sencha-workspace/packages/slate-core-data"
+root = "sencha-workspace/packages/slate-ui-classic"
 files = "**"


### PR DESCRIPTION
- fix: correct roots for extjs packages