### PR TITLE
Release: slate v2.9.7

### DIFF
--- a/php-classes/Slate/Progress/AbstractSectionTermReportsRequestHandler.php
+++ b/php-classes/Slate/Progress/AbstractSectionTermReportsRequestHandler.php
@@ -169,12 +169,23 @@ abstract class AbstractSectionTermReportsRequestHandler extends \RecordsRequestH
 
         // collect recipients
         foreach ($students AS &$student) {
+            $sentRecipients = SectionInterimReportRecipient::getAllByWhere([
+                'StudentID' => $student['student']->ID,
+                'TermID' => $conditions['TermID']
+            ]);
+
+            $sentByEmail = [];
+            foreach ($sentRecipients as $sentRecipient) {
+                $sentByEmail[$sentRecipient->EmailContactID] = $sentRecipient->Status;
+            }
+
             if (in_array('student', $recipients)) {
                 $student['recipients'][] = [
                     'id' => $student['student']->ID,
                     'name' => $student['student']->FullName,
                     'email' => $student['student']->Email,
-                    'relationship' => 'student'
+                    'relationship' => 'student',
+                    'status' => $sentByEmail[$student['student']->PrimaryEmailID] ?: 'proposed'
                 ];
             }
 
@@ -183,7 +194,8 @@ abstract class AbstractSectionTermReportsRequestHandler extends \RecordsRequestH
                     'id' => $student['student']->Advisor->ID,
                     'name' => $student['student']->Advisor->FullName,
                     'email' => $student['student']->Advisor->Email,
-                    'relationship' => 'advisor'
+                    'relationship' => 'advisor',
+                    'status' => $sentByEmail[$student['student']->Advisor->PrimaryEmailID] ?: 'proposed'
                 ];
             }
 
@@ -197,7 +209,8 @@ abstract class AbstractSectionTermReportsRequestHandler extends \RecordsRequestH
                         'id' => $GuardianRelationship->RelatedPerson->ID,
                         'name' => $GuardianRelationship->RelatedPerson->FullName,
                         'email' => $GuardianRelationship->RelatedPerson->Email,
-                        'relationship' => $GuardianRelationship->Label
+                        'relationship' => $GuardianRelationship->Label,
+                        'status' => $sentByEmail[$GuardianRelationship->RelatedPerson->PrimaryEmailID] ?: 'proposed'
                     ];
                 }
             }

--- a/php-classes/Slate/Progress/AbstractSectionTermReportsRequestHandler.php
+++ b/php-classes/Slate/Progress/AbstractSectionTermReportsRequestHandler.php
@@ -71,6 +71,7 @@ abstract class AbstractSectionTermReportsRequestHandler extends \RecordsRequestH
     public static function handleEmailsRequest()
     {
         $GLOBALS['Session']->requireAccountLevel('Staff');
+        set_time_limit(0);
         $recordClass = static::$recordClass;
 
         $responseData = [];

--- a/php-classes/Slate/Progress/AbstractSectionTermReportsRequestHandler.php
+++ b/php-classes/Slate/Progress/AbstractSectionTermReportsRequestHandler.php
@@ -113,7 +113,7 @@ abstract class AbstractSectionTermReportsRequestHandler extends \RecordsRequestH
                 // prepare template data
                 $emailData = static::getEmailTemplateData($reports);
 
-                // add central achive recipient
+                // add central achieve recipient
                 // TODO: make this configurable
                 if (Slate::$userEmailDomain) {
                     if (count($emailData['students']) == 1) {

--- a/php-classes/Slate/Progress/SectionInterimReportRecipient.php
+++ b/php-classes/Slate/Progress/SectionInterimReportRecipient.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Slate\Progress;
+
+use Emergence\People\ContactPoint\Email;
+use Slate\Courses\Section;
+use Slate\People\Student;
+use Slate\Term;
+
+class SectionInterimReportRecipient extends \ActiveRecord
+{
+    public static $tableName = 'section_interim_report_recipients';
+    public static $singularNoun = 'section interim report recipient';
+    public static $pluralNoun = 'section interim report recipients';
+    public static $updateOnDuplicateKey = true;
+
+    public static $fields = [
+        'StudentID' => 'uint',
+        'TermID' => 'uint',
+        'EmailContactID' => 'uint',
+        'Status' => [
+            'type' => 'enum',
+            'values' => ['pending', 'sent', 'bounced'],
+            'default' => 'pending'
+        ]
+    ];
+
+    public static $relationships = [
+        'Student' => [
+            'type' => 'one-one',
+            'class' => Student::class
+        ],
+        'Term' => [
+            'type' => 'one-one',
+            'class' => Term::class
+        ],
+        'EmailContact' => [
+            'type' => 'one-one',
+            'class' => Email::class
+        ]
+    ];
+
+    public static $dynamicFields = [
+        'Student',
+        'Term',
+        'EmailContact'
+    ];
+
+    public static $indexes = [
+        'SectionInterimReportRecipient' => [
+            'fields' => ['StudentID', 'TermID', 'EmailContactID'],
+            'unique' => true
+        ]
+    ];
+}

--- a/php-classes/Slate/Progress/SectionInterimReportsRequestHandler.php
+++ b/php-classes/Slate/Progress/SectionInterimReportsRequestHandler.php
@@ -6,4 +6,5 @@ namespace Slate\Progress;
 class SectionInterimReportsRequestHandler extends AbstractSectionTermReportsRequestHandler
 {
     public static $recordClass = SectionInterimReport::class;
+    public static $recipientClass = SectionInterimReportRecipient::class;
 }

--- a/php-classes/Slate/Progress/SectionTermReportRecipient.php
+++ b/php-classes/Slate/Progress/SectionTermReportRecipient.php
@@ -6,11 +6,11 @@ use Emergence\People\ContactPoint\Email;
 use Slate\People\Student;
 use Slate\Term;
 
-class SectionInterimReportRecipient extends \ActiveRecord
+class SectionTermReportRecipient extends \ActiveRecord
 {
-    public static $tableName = 'section_interim_report_recipients';
-    public static $singularNoun = 'section interim report recipient';
-    public static $pluralNoun = 'section interim report recipients';
+    public static $tableName = 'section_term_report_recipients';
+    public static $singularNoun = 'section term report recipient';
+    public static $pluralNoun = 'section term report recipients';
     public static $updateOnDuplicateKey = true;
 
     public static $fields = [
@@ -46,7 +46,7 @@ class SectionInterimReportRecipient extends \ActiveRecord
     ];
 
     public static $indexes = [
-        'SectionInterimReportRecipient' => [
+        'SectionTermReportRecipient' => [
             'fields' => ['StudentID', 'TermID', 'EmailContactID'],
             'unique' => true
         ]

--- a/php-classes/Slate/Progress/SectionTermReportsRequestHandler.php
+++ b/php-classes/Slate/Progress/SectionTermReportsRequestHandler.php
@@ -6,4 +6,5 @@ namespace Slate\Progress;
 class SectionTermReportsRequestHandler extends AbstractSectionTermReportsRequestHandler
 {
     public static $recordClass = SectionTermReport::class;
+    public static $recipientClass = SectionTermReportRecipient::class;
 }

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
@@ -158,6 +158,7 @@ Ext.define('SlateAdmin.controller.progress.interims.Email', {
             Slate.API.request({
                 method: 'POST',
                 url: '/progress/section-interim-reports/*emails',
+                timeout: 300000,
                 jsonData: emails,
                 callback: function(options, success, response) {
                     var data = response.data || {};

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
@@ -109,8 +109,13 @@ Ext.define('SlateAdmin.controller.progress.interims.Email', {
             count = emailsStore.getCount();
 
         if (count) {
-            me.getEmailsTotalCmp().setText(count + ' report email' + (count == 1 ? '' : 's') + ' ready');
-            me.getSendEmailsBtn().enable();
+            if (emailsStore.getProxy().getReader().rawData.author) {
+                me.getEmailsTotalCmp().setText('Auther filter for preview only, cannot send partial reports');
+                me.getSendEmailsBtn().disable();
+            } else {
+                me.getEmailsTotalCmp().setText(count + ' report email' + (count == 1 ? '' : 's') + ' ready');
+                me.getSendEmailsBtn().enable();
+            }
         } else {
             me.resetEmails();
             me.resetPreview();

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
@@ -136,17 +136,27 @@ Ext.define('SlateAdmin.controller.progress.interims.Email', {
             emailsStore = me.getProgressInterimsEmailsStore(),
             emailsCount = emailsStore.getCount(),
             i = 0, email,
-            emails = [];
+            emails = [], recipients;
 
         sendEmailsBtn.disable();
 
         for (; i < emailsCount; i++) {
             email = emailsStore.getAt(i);
+            recipients = email.get('recipients').filter(recipient => recipient.status == 'proposed');
+
+            if (!recipients.length) {
+                continue;
+            }
 
             emails.push({
                 reports: email.get('reports'),
-                recipients: Ext.Array.pluck(email.get('recipients'), 'id')
+                recipients: Ext.Array.pluck(recipients, 'id')
             });
+        }
+
+        if (emails.length == 0) {
+            Ext.Msg.alert('No emails sent', 'No new emails need to be sent');
+            return;
         }
 
         Ext.Msg.confirm('Send report emails', 'Are you sure you want to send out '+emails.length+' emails now?', function(btn) {

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
@@ -136,17 +136,27 @@ Ext.define('SlateAdmin.controller.progress.terms.Email', {
             emailsStore = me.getProgressTermsEmailsStore(),
             emailsCount = emailsStore.getCount(),
             i = 0, email,
-            emails = [];
+            emails = [], recipients;
 
         sendEmailsBtn.disable();
 
         for (; i < emailsCount; i++) {
             email = emailsStore.getAt(i);
+            recipients = email.get('recipients').filter(recipient => recipient.status == 'proposed');
+
+            if (!recipients.length) {
+                continue;
+            }
 
             emails.push({
                 reports: email.get('reports'),
-                recipients: Ext.Array.pluck(email.get('recipients'), 'id')
+                recipients: Ext.Array.pluck(recipients, 'id')
             });
+        }
+
+        if (emails.length == 0) {
+            Ext.Msg.alert('No emails sent', 'No new emails need to be sent');
+            return;
         }
 
         Ext.Msg.confirm('Send report emails', 'Are you sure you want to send out '+emails.length+' emails now?', function(btn) {

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
@@ -158,6 +158,7 @@ Ext.define('SlateAdmin.controller.progress.terms.Email', {
             Slate.API.request({
                 method: 'POST',
                 url: '/progress/section-term-reports/*emails',
+                timeout: 300000,
                 jsonData: emails,
                 callback: function(options, success, response) {
                     var data = response.data || {};

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
@@ -109,8 +109,13 @@ Ext.define('SlateAdmin.controller.progress.terms.Email', {
             count = emailsStore.getCount();
 
         if (count) {
-            me.getEmailsTotalCmp().setText(count + ' report email' + (count == 1 ? '' : 's') + ' ready');
-            me.getSendEmailsBtn().enable();
+            if (emailsStore.getProxy().getReader().rawData.author) {
+                me.getEmailsTotalCmp().setText('Auther filter for preview only, cannot send partial reports');
+                me.getSendEmailsBtn().disable();
+            } else {
+                me.getEmailsTotalCmp().setText(count + ' report email' + (count == 1 ? '' : 's') + ' ready');
+                me.getSendEmailsBtn().enable();
+            }
         } else {
             me.resetEmails();
             me.resetPreview();

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Container.js
@@ -67,14 +67,6 @@ Ext.define('SlateAdmin.view.progress.interims.email.Container', {
                             valueField: 'Username'
                         },
                         {
-                            name: 'author',
-                            fieldLabel: 'Author',
-
-                            store: 'progress.interims.Authors',
-                            displayField: 'SortName',
-                            valueField: 'Username'
-                        },
-                        {
                             xtype: 'slate-personfield',
                             name: 'student',
                             fieldLabel: 'Student',
@@ -91,7 +83,15 @@ Ext.define('SlateAdmin.view.progress.interims.email.Container', {
                             },
                             valueField: 'Handle',
                             displayField: 'namesPath'
-                        }
+                        },
+                        {
+                            name: 'author',
+                            fieldLabel: 'Author',
+
+                            store: 'progress.interims.Authors',
+                            displayField: 'SortName',
+                            valueField: 'Username'
+                        },
                     ]
                 },
                 {

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Container.scss
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Container.scss
@@ -1,0 +1,5 @@
+.progress-interims-email-container {
+    .email-preview {
+        background: white;
+    }
+}

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Grid.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Grid.js
@@ -45,7 +45,7 @@ Ext.define('SlateAdmin.view.progress.interims.email.Grid', {
             tpl: [
                 '<ul class="recipients-list">',
                 '   <tpl for="recipients">',
-                '       <li>{name} <span class="recipient-contact">{email}</span> ({relationship})</li>',
+                '       <li class="status-{status}">{name} <span class="recipient-contact">{email}</span> ({relationship})</li>',
                 '   </tpl>',
                 '</ul>'
             ]

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Container.js
@@ -67,14 +67,6 @@ Ext.define('SlateAdmin.view.progress.terms.email.Container', {
                             valueField: 'Username'
                         },
                         {
-                            name: 'author',
-                            fieldLabel: 'Author',
-
-                            store: 'progress.terms.Authors',
-                            displayField: 'SortName',
-                            valueField: 'Username'
-                        },
-                        {
                             xtype: 'slate-personfield',
                             name: 'student',
                             fieldLabel: 'Student',
@@ -91,6 +83,14 @@ Ext.define('SlateAdmin.view.progress.terms.email.Container', {
                             },
                             valueField: 'Handle',
                             displayField: 'namesPath'
+                        },
+                        {
+                            name: 'author',
+                            fieldLabel: 'Author',
+
+                            store: 'progress.terms.Authors',
+                            displayField: 'SortName',
+                            valueField: 'Username'
                         }
                     ]
                 },

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Container.scss
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Container.scss
@@ -1,0 +1,5 @@
+.progress-terms-email-container {
+    .email-preview {
+        background: white;
+    }
+}

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Grid.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Grid.js
@@ -45,7 +45,7 @@ Ext.define('SlateAdmin.view.progress.terms.email.Grid', {
             tpl: [
                 '<ul class="recipients-list">',
                 '   <tpl for="recipients">',
-                '       <li>{name} <span class="recipient-contact">{email}</span> ({relationship})</li>',
+                '       <li class="status-{status}">{name} <span class="recipient-contact">{email}</span> ({relationship})</li>',
                 '   </tpl>',
                 '</ul>'
             ]

--- a/sencha-workspace/SlateAdmin/sass/src/view/progress/interims/email/Grid.scss
+++ b/sencha-workspace/SlateAdmin/sass/src/view/progress/interims/email/Grid.scss
@@ -2,15 +2,27 @@
     list-style: none;
     margin: 0;
     padding: 0;
-    
+
     li {
         margin-bottom: 0.2857em;
-        
+
         &:last-child {
             margin-bottom: 0;
         }
+
+        &:before {
+            color: lightgrey;
+            content: '\f0c8'; // fa-square
+            font-family: FontAwesome;
+            margin-right: 0.5em;
+        }
+
+        &.status-sent:before {
+            color: green;
+            content: '\f14a'; // fa-check-square
+        }
     }
-    
+
     .recipient-contact {
         background-color: tint($accent-color, 90%);
         border-radius: 3px;


### PR DESCRIPTION
- feat: record report recipients
- feat: show sent status in terms/interims email grids
- feat: skip sending term/interim reports to existing recipients
- feat: disable sending reports when author filtered
- fix: fill background for email previews
- fix: increase timeouts for sending report emails
