### PR TITLE
feature: add mobile-optimized omnibar

### DIFF
--- a/html-templates/includes/site.user-tools.tpl
+++ b/html-templates/includes/site.user-tools.tpl
@@ -1,4 +1,130 @@
-<div class="slate-omnibar site">
+{template omnibarChildLink link parentLink=null labelPrefix=null}
+    {if $parentLink && !$link.icon && !$link.iconSrc}
+        {if $parentLink.icon}
+            {$link.icon = $parentLink.icon}
+        {/if}
+        {if $parentLink.iconSrc}
+            {$link.iconSrc = $parentLink.iconSrc}
+        {/if}
+    {/if}
+
+    {if $link.href}
+        <li class="omnibar-menu-item" {html_attributes_encode $link prefix='data-' deep=no}>
+            <a class="omnibar-menu-link" href="{$link.href|escape}" title="{$link.label|escape}">
+                <figure class="omnibar-menu-icon">
+                    <div class="omnibar-menu-image-ct">
+                        <svg class="omnibar-menu-image-bg"><use xlink:href="{versioned_url img/slate-icons/slate-icons.svg}#icon-squircle"/></svg>
+                        <svg class="omnibar-menu-image"><use xlink:href="{versioned_url img/slate-icons/slate-icons.svg}#icon-{$link.icon|default:'link'|escape}"/></svg>
+                    </div>
+                    <figcaption class="omnibar-menu-label">
+                        {if $labelPrefix}
+                            <small>{$labelPrefix|escape}</small>
+                        {/if}
+                        {$link.shortLabel|default:$link.label|escape}
+                    </figcaption>
+                </figure>
+            </a>
+        </li>
+    {/if}
+
+    {if $link.children}
+        {foreach item=childLink from=$link.children}
+            {$parentLabel = $link.shortLabel|default:$link.label}
+            {omnibarChildLink $childLink parentLink=$link labelPrefix=tif($labelPrefix, cat($labelPrefix, ' » ', $parentLabel), $parentLabel)}
+        {/foreach}
+    {/if}
+{/template}
+
+{template omnibarLink link}
+    <li class="omnibar-item {if $link.icon}icon-{$link.icon}{/if}" {html_attributes_encode $link prefix='data-' deep=no}>
+        <{if $link.href}a href="{$link.href|escape}"{else}span{/if} class="omnibar-link" {if $link.label != $link.shortLabel}title="{$link.label|escape}"{/if}>
+            {if $link.iconSrc}
+                <img class="omnibar-link-image" src="{$link.iconSrc|escape}" alt="" width="24" height="24">
+            {/if}
+            {$link.shortLabel|default:$link.label|escape}
+        </{tif $link.href ? a : span}>
+
+        {if $link.children}
+            <div class="omnibar-menu-ct">
+                <ul class="omnibar-menu">
+                    {foreach item=childLink from=$link.children}
+                        {omnibarChildLink $childLink parentLink=$link}
+                    {/foreach}
+                </ul>
+            </div>
+        {/if}
+    </li>
+{/template}
+
+{template omnibarMobileGroup link}
+    <div class="omnibar-overlay-group">
+        <h2 class="omnibar-overlay-heading">
+            {if $link.href}<a href="{$link.href|escape}" {if $link.label != $link.shortLabel}title="{$link.label|escape}"{/if}>{/if}
+                {if $link.iconSrc}
+                    <img class="omnibar-link-image" src="{$link.iconSrc|escape}" alt="" width="24" height="24">
+                {/if}
+                {$link.shortLabel|default:$link.label|escape}
+            {if $link.href}&nbsp;<i class="fa fa-arrow-circle-right"></i></a>{/if}
+        </h2>
+
+        {if $link.children}
+            <ul class="ombnibar-overlay-group-items">
+            {foreach item=childLink from=$link.children}
+                {omnibarChildLink $childLink parentLink=$link}
+            {/foreach}
+            </ul>
+        {/if}
+    </div>
+{/template}
+
+<div class="slate-omnibar site mobile-only">
+    <div class="inner">
+        <ul class="omnibar-items">
+            {if $.User}
+            <li class="omnibar-item">
+                <a class="omnibar-link root-link" href="/dashboard">
+                    <img class="slate-logo" src="{versioned_url img/slate-logo-white.svg}" width="41" height="32" alt="Slate">
+                </a>
+            </li>
+            {/if}
+
+            <li class="omnibar-item omnibar-search-item">
+                <form class="omnibar-search-form" action="/search">
+                    <input class="omnibar-search-field" name="q" type="search" placeholder="Search" required>
+                </form>
+            </li>
+
+            {if $.User} {* show menu button and build overlay *}
+            <li class="omnibar-item omnibar-toggle-item">
+                <input class="omnibar-toggle-input" id="omnibar-toggle" type="checkbox">
+                <label class="omnibar-toggle-label" for="omnibar-toggle">
+                    <svg class="omnibar-toggle-icon" viewBox="0 0 16 16">
+                        <g fill="currentColor">
+                            <rect width="100%" height="12.5%" y="43.75%"/>
+                            <rect width="100%" height="12.5%" y="43.75%"/>
+                            <rect width="100%" height="12.5%" y="43.75%"/>
+                        </g>
+                    </svg>
+                </label>
+                <div class="omnibar-mobile-overlay">
+                    <div class="omnibar-overlay-background"></div>
+                    <div class="omnibar-overlay-contents">
+                        {foreach item=link from=Slate\UI\Omnibar::getLinks()}
+                            {omnibarMobileGroup $link}
+                        {/foreach}
+                    </div>
+                </div>
+            </li>
+            {else} {* just show the link(s), presumably to log in *}
+                {foreach item=link from=Slate\UI\Omnibar::getLinks()}
+                    {omnibarLink $link}
+                {/foreach}
+            {/if}
+        </ul>
+    </div>
+</div>
+
+<div class="slate-omnibar site mobile-hidden">
     <div class="inner {if $fluid}fluid-width{/if}">
         <ul class="omnibar-items">
             {if $.User}
@@ -15,64 +141,6 @@
                     <input class="omnibar-search-field" name="q" type="search" placeholder="Search" required>
                 </form>
             </li>
-
-            {template omnibarChildLink link parentLink=null labelPrefix=null}
-                {if $parentLink && !$link.icon && !$link.iconSrc}
-                    {if $parentLink.icon}
-                        {$link.icon = $parentLink.icon}
-                    {/if}
-                    {if $parentLink.iconSrc}
-                        {$link.iconSrc = $parentLink.iconSrc}
-                    {/if}
-                {/if}
-
-                {if $link.href}
-                    <li class="omnibar-menu-item" {html_attributes_encode $link prefix='data-' deep=no}>
-                        <a class="omnibar-menu-link" href="{$link.href|escape}" title="{$link.label|escape}">
-                            <figure class="omnibar-menu-icon">
-                                <div class="omnibar-menu-image-ct">
-                                    <svg class="omnibar-menu-image-bg"><use xlink:href="{versioned_url img/slate-icons/slate-icons.svg}#icon-squircle"/></svg>
-                                    <svg class="omnibar-menu-image"><use xlink:href="{versioned_url img/slate-icons/slate-icons.svg}#icon-{$link.icon|default:'link'|escape}"/></svg>
-                                </div>
-                                <figcaption class="omnibar-menu-label">
-                                    {if $labelPrefix}
-                                        <small class="muted">{$labelPrefix|escape}</small>
-                                    {/if}
-                                    {$link.shortLabel|default:$link.label|escape}
-                                </figcaption>
-                            </figure>
-                        </a>
-                    </li>
-                {/if}
-
-                {if $link.children}
-                    {foreach item=childLink from=$link.children}
-                        {$parentLabel = $link.shortLabel|default:$link.label}
-                        {omnibarChildLink $childLink parentLink=$link labelPrefix=tif($labelPrefix, cat($labelPrefix, ' » ', $parentLabel), $parentLabel)}
-                    {/foreach}
-                {/if}
-            {/template}
-
-            {template omnibarLink link}
-                <li class="omnibar-item {if $link.icon}icon-{$link.icon}{/if}" {html_attributes_encode $link prefix='data-' deep=no}>
-                    <{if $link.href}a href="{$link.href|escape}"{else}span{/if} class="omnibar-link" {if $link.label != $link.shortLabel}title="{$link.label|escape}"{/if}>
-                        {if $link.iconSrc}
-                            <img class="omnibar-link-image" src="{$link.iconSrc|escape}" alt="{$link.label|escape}" width="24" height="24">
-                        {/if}
-                        {$link.shortLabel|default:$link.label|escape}
-                    </{tif $link.href ? a : span}>
-
-                    {if $link.children}
-                        <div class="omnibar-menu-ct">
-                            <ul class="omnibar-menu">
-                                {foreach item=childLink from=$link.children}
-                                    {omnibarChildLink $childLink parentLink=$link}
-                                {/foreach}
-                            </ul>
-                        </div>
-                    {/if}
-                </li>
-            {/template}
 
             {foreach item=link from=Slate\UI\Omnibar::getLinks()}
                 {omnibarLink $link}

--- a/php-classes/Slate/UI/Adapters/Courses.php
+++ b/php-classes/Slate/UI/Adapters/Courses.php
@@ -13,27 +13,39 @@ class Courses implements \Slate\UI\ILinksSource
 
     public static $courseIcons = [
         'arithmetic' => [
-            'courseCodes' => ['ALG']
+            'courseCodes' => ['ALG', 'CALC', 'MATH', 'PRECALC', 'STAT']
         ],
         'writing' => [
-            'courseCodes' => ['ENG']
+            'courseCodes' => ['ENG', 'ELA', 'PHILO', 'JOURNAL', 'SS']
         ],
         'chemistry' => [
-            'courseCodes' => ['BIO', 'CHEM']
+            'courseCodes' => ['BIO', 'CHEM', 'ADVCHEM', 'BC', 'ENVSCI', 'PHYS']
         ],
         'globe' => [
-            'courseCodes' => ['HIS', 'HIST', 'GEO']
+            'courseCodes' => ['HIS', 'HIST', 'GEO', 'AMHIST', 'WRLDHIST']
         ],
         'palette' => [
-            'courseCodes' => ['ART']
+            'courseCodes' => ['ART', 'CRAFTS', 'DRAMA', 'MUSIC', 'SRART']
         ],
         'binoculars' => [
         ],
         'heartbeat' => [
-            'courseCodes' => ['HEALTH']
+            'courseCodes' => ['HEALTH', 'PE', 'ANAT']
         ],
         'intl' => [
-            'courseCodes' => ['SP']
+            'courseCodes' => ['SP', 'FR', 'GR', 'SASTUDIES']
+        ],
+        'graduate' => [
+            'courseCodes' => ['ILP', 'ADV', 'CAP', 'ISP', 'SAT']
+        ],
+        'users' => [
+            'courseCodes' => ['INTERSECT', 'AFAM', 'AMGOV']
+        ],
+        'network' => [
+            'courseCodes' => ['PODCAST', 'DIGFILM', 'ADVCSE', 'CSE', 'CTEENG', 'ENGIN', 'TECH']
+        ],
+        'chat' => [
+            'courseCodes' => ['DEB']
         ]
     ];
 
@@ -79,7 +91,7 @@ class Courses implements \Slate\UI\ILinksSource
 
         $linkGroups = [
             'Courses' => [
-                '_icon' => 'courses',
+                '_icon' => 'diploma',
                 '_href' => Section::$collectionRoute.'?'.http_build_query([ 'term' => '*current' ]),
                 '_weight' => $weight++,
                 '_children' => array_map(function(Section $Section) {
@@ -101,7 +113,7 @@ class Courses implements \Slate\UI\ILinksSource
                 }
 
                 $linkGroups[$Ward->Username] = [
-                    '_icon' => 'courses',
+                    '_icon' => 'diploma',
                     '_href' => Section::$collectionRoute.'?'.http_build_query([ 'term' => '*current', 'enrolled_user' => $Ward->Username ]),
                     '_label' => $Ward->FirstNamePossessive . ' Courses',
                     '_weight' => $weight++,

--- a/site-root/sass/slate/modules/_branding.scss
+++ b/site-root/sass/slate/modules/_branding.scss
@@ -2,7 +2,8 @@
     background-color: rgba(white, 0.85);
 
     > .inner {
-        padding: 0.75em 0 0.5em;
+        padding-bottom: 0.5em;
+        padding-top: 0.75em;
     }
 
     a {

--- a/site-root/sass/slate/modules/_hero-text.scss
+++ b/site-root/sass/slate/modules/_hero-text.scss
@@ -1,27 +1,34 @@
 .hero-ct {
-    bottom: 0;
     box-sizing: border-box;
     display: none;
-    left: 50%;
-    position: absolute;
-    @include translateX(-50%);
 
     .reveal-hero & {
         display: block;
+        margin: 1.5em 0;
+    }
+
+    @media #{$mq-wide} {
+        bottom: 0;
+        left: 50%;
+        position: absolute;
+        @include translateX(-50%);
     }
 }
 
 .hero-text {
     background-color: rgba($text-color, .9);
-    bottom: 2em;
     color: $page-bg-color;
     font-size: large;
     padding: 1em;
-    position: absolute;
-    right: 0;
-    width: 61.8%;
 
     > :last-child {
         margin-bottom: 0;
+    }
+
+    @media #{$mq-wide} {
+        bottom: 2em;
+        position: absolute;
+        right: 0;
+        width: 61.8%;
     }
 }

--- a/site-root/sass/slate/modules/_omnibar.scss
+++ b/site-root/sass/slate/modules/_omnibar.scss
@@ -1,3 +1,5 @@
+
+
 @-webkit-keyframes menu-in {
     from {
         opacity: 0;
@@ -42,9 +44,10 @@
     box-shadow: 0 0 0.5em rgba(black, 0.6);
     color: white;
     left: 0;
+    max-width: 100vw;
     position: fixed;
-    right: 0;
     top: 0;
+    width: 100%;
     z-index: 99;
 
     a,
@@ -186,6 +189,8 @@
 }
 
 .omnibar-menu-link {
+    display: block;
+
     &:hover,
     &:focus {
         .omnibar-menu-image-bg {
@@ -209,6 +214,7 @@
     -webkit-animation: menu-in 300ms both cubic-bezier(0.2, 0.8, 0, 1.2);
             animation: menu-in 300ms both cubic-bezier(0.2, 0.8, 0, 1.2);
     -webkit-backface-visibility: hidden;
+            backface-visibility: hidden;
 
     $animation-stagger: .0167s;
 
@@ -242,6 +248,7 @@
     -webkit-animation: menu-in 200ms both cubic-bezier(0.2, 0.8, 0, 1.2);
             animation: menu-in 200ms both cubic-bezier(0.2, 0.8, 0, 1.2);
     -webkit-backface-visibility: hidden;
+            backface-visibility: hidden;
 
   $animation-stagger: 15ms;
 
@@ -258,7 +265,6 @@
     fill: currentColor;
     height: 75%;
     position: relative;
-    // @include transition(250ms cubic-bezier(0.075, 0.820, 0.165, 1.000));
     width: 75%;
 }
 
@@ -270,7 +276,166 @@
 
     small {
         display: block;
-        margin: .25em 0 .125em
+        margin: .25em 0 .125em;
+        opacity: .4;
     }
 }
 
+.slate-omnibar.mobile-only {
+    .omnibar-link {
+        padding: .875em;
+    }
+
+    .omnibar-search-item {
+        margin: 0;
+    }
+
+    .omnibar-search-field {
+        height: 100%;
+        width: 2.25em;
+
+        @include input-placeholder(rgba(white, (1/3)));
+
+        &:focus {
+            width: 100%;
+        }
+    }
+}
+
+.omnibar-toggle-item {
+    position: relative;
+}
+
+.omnibar-toggle-input {
+    height: 100%;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
+
+.omnibar-toggle-icon {
+    height: 1em;
+    padding: .875em;
+    width: 1em;
+}
+
+.omnibar-mobile-overlay {
+    bottom: 0;
+    left: 0;
+    pointer-events: none;
+    position: fixed;
+    right: 0;
+    top: 2.75em;
+}
+
+.omnibar-overlay-background {
+    background-color: rgba(#444, .97);
+    bottom: 0;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: 400ms;
+}
+
+.omnibar-overlay-contents {
+    bottom: 0;
+    left: 0;
+    opacity: 0;
+    overflow: auto;
+    position: absolute;
+    right: 0;
+    top: 0;
+    padding: 1.25em;
+    transform: translateY(-1em);
+    transition: 200ms;
+}
+
+.omnibar-toggle-icon rect {
+    transform-origin: center;
+    transition: 200ms;
+
+    // i'd rather use %s but safari doesn't like them here
+    &:nth-child(1) { transform: translateY(-5px); }
+    &:nth-child(3) { transform: translateY(5px); }
+}
+
+.omnibar-toggle-input:checked {
+    ~ .omnibar-toggle-label {
+        rect:nth-child(1) {
+            transform: rotate(45deg) translateY(0);
+        }
+
+        rect:nth-child(2) {
+            transform: scaleX(0);
+        }
+
+        rect:nth-child(3) {
+            transform: rotate(-45deg) translateY(0);
+        }
+    }
+
+    ~ .omnibar-mobile-overlay {
+        pointer-events: all;
+
+        .omnibar-overlay-background {
+            opacity: 1;
+        }
+
+        .omnibar-overlay-contents {
+            opacity: 1;
+            transform: translate(0);
+            transition-delay: 200ms;
+        }
+
+        .omnibar-overlay-group {
+            opacity: 1;
+            transform: scale(1);
+
+            $animation-stagger: 75ms;
+            @for $i from 1 through 10 {
+                &:nth-child(n + #{$i}) {
+                    transition-delay: $animation-stagger * $i;
+                }
+            }
+        }
+    }
+}
+
+.omnibar-overlay-group {
+    opacity: 0;
+    transform: scale(.95) translateY(-1em);
+    transform-origin: right top;
+    transition: 200ms;
+}
+
+.ombnibar-overlay-group-items {
+    display: grid;
+    grid-gap: 1em .5em;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    margin: 0 0 2em;
+    padding: 0;
+
+    .omnibar-menu-item {
+        margin: 0;
+    }
+
+    .omnibar-menu-icon {
+        width: 100%;
+    }
+
+    .omnibar-menu-img-ct {
+        height: 60px;
+        width: 60px;
+    }
+}
+
+.omnibar-overlay-heading {
+    border-bottom: 1px solid rgba(white, .3);
+    color: white;
+    margin: 0 0 1em;
+    padding: 0 0 .25em;
+}


### PR DESCRIPTION
## Changes

- Adds mobile-optimized version of the omnibar
- Corrects some mobile layout issues on the default homepage
- **(Not sure if this belongs in base Slate?)** Improves matching of courses to icons based on SLA's course list

## Known issues

- Icons are not pulled in for the "group headings" (Courses, Tools, etc)
- Layout of login modal is wonky on mobile (missing padding)
  - This should probably be fixed in skeleton-v2

Default | Opened | Search | Logged out
-- | -- | -- | --
![mobile-omnibar](https://user-images.githubusercontent.com/1154929/91622682-54640b00-e966-11ea-8e57-77869ed5043f.png) | ![mobile-omnibar-open](https://user-images.githubusercontent.com/1154929/91622683-55953800-e966-11ea-9049-2db2ee028e69.png) | ![mobile-omnibar-search](https://user-images.githubusercontent.com/1154929/91622685-55953800-e966-11ea-9761-6bf5c5c3a68c.png) | ![mobile-omnibar-logged-out](https://user-images.githubusercontent.com/1154929/91622686-562dce80-e966-11ea-973a-bf5325b7ad9a.png)
