### PR TITLE
Release: slate v2.10.1

### DIFF
--- a/.holo/sources/skeleton-v2.toml
+++ b/.holo/sources/skeleton-v2.toml
@@ -1,6 +1,6 @@
 [holosource]
 url = "https://github.com/JarvusInnovations/emergence-skeleton-v2"
-ref = "refs/tags/v2.4.3"
+ref = "refs/tags/v2.4.4"
 
 [holosource.project]
 holobranch = "emergence-skeleton"

--- a/php-classes/Slate/Connectors/GoogleApps/Connector.php
+++ b/php-classes/Slate/Connectors/GoogleApps/Connector.php
@@ -147,10 +147,10 @@ class Connector extends \Emergence\Connectors\AbstractConnector implements \Emer
             // update existing remote user
             if ($googleUser) {
                 if (!$DomainEmailPoint) {
-                    $Job->error('Cannot update existing remote user {username} because they don\'t have an email contact point matching the domain', [
+                    $Job->debug('Cannot update existing remote user {username} because they don\'t have an email contact point matching the domain', [
                         'username' => $User->Username
                     ]);
-                    $results['outcome']['failed']['no-domain-email-contact-point']++;
+                    $results['outcome']['skipped']['existing-user-no-domain-email-contact-point']++;
                     continue;
                 }
 


### PR DESCRIPTION
## Improvements

- fix(connectors/google-apps): reclassify unmapped existing user as a skip

## Technical

- chore: bump skeleton-v2 to v2.4.4