### PR TITLE
feat: extended dynamic section titles [SCHOOL-15]

### DIFF
--- a/html-templates/includes/site.user-tools.tpl
+++ b/html-templates/includes/site.user-tools.tpl
@@ -20,7 +20,7 @@
                         {if $labelPrefix}
                             <small>{$labelPrefix|escape}</small>
                         {/if}
-                        {$link.shortLabel|default:$link.label|escape}
+                        {$link.label|default:$link.shortLabel|escape}
                     </figcaption>
                 </figure>
             </a>

--- a/html-templates/progress/section-interim-reports/_body.email.tpl
+++ b/html-templates/progress/section-interim-reports/_body.email.tpl
@@ -2,7 +2,7 @@
 {$Instructor = $Section->Instructors.0}
 
 {block header}
-    <h{$headingLevel} style="margin: 0 0 1em; color: #004b66;">{$Section->Title|escape}</h{$headingLevel}>
+    <h{$headingLevel} style="margin: 0 0 1em; color: #004b66;">{$Section->getTitle()|escape}</h{$headingLevel}>
 {/block}
 
 {block teachers}

--- a/html-templates/progress/section-interim-reports/_body.tpl
+++ b/html-templates/progress/section-interim-reports/_body.tpl
@@ -1,6 +1,6 @@
 <header class="doc-header">
     {block header}
-        <h{$headingLevel} class="item-title">{block title}{$Report->Section->Title|escape}{/block}</h{$headingLevel}>
+        <h{$headingLevel} class="item-title">{block title}{$Report->Section->getTitle()|escape}{/block}</h{$headingLevel}>
 
         <div class="meta">
             {block meta}

--- a/html-templates/progress/section-term-reports/_body.email.tpl
+++ b/html-templates/progress/section-term-reports/_body.email.tpl
@@ -2,7 +2,7 @@
 {$Instructor = $Section->Instructors.0}
 
 {block header}
-    <h{$headingLevel} style="margin: 0 0 1em; color: #004b66;">{$Section->Title}</h{$headingLevel}>
+    <h{$headingLevel} style="margin: 0 0 1em; color: #004b66;">{$Section->getTitle()}</h{$headingLevel}>
 {/block}
 
 {block teachers}

--- a/html-templates/progress/section-term-reports/_body.tpl
+++ b/html-templates/progress/section-term-reports/_body.tpl
@@ -1,6 +1,6 @@
 <header class="doc-header">
     {block header}
-        <h{$headingLevel} class="item-title">{block title}{$Report->Section->Title|escape}{/block}</h{$headingLevel}>
+        <h{$headingLevel} class="item-title">{block title}{$Report->Section->getTitle()|escape}{/block}</h{$headingLevel}>
 
         <div class="meta">
             {block meta}

--- a/html-templates/sections/courseSection.tpl
+++ b/html-templates/sections/courseSection.tpl
@@ -4,7 +4,7 @@
     <link rel="alternate" type="application/rss+xml" title="RSS" href="/sections/{$data->Handle}/rss">
 {/block}
 
-{block title}{$data->Title|escape} &mdash; {$dwoo.parent}{/block}
+{block title}{$data->getTitle()|escape} &mdash; {$dwoo.parent}{/block}
 
 {block js-bottom}
     <script type="text/javascript">
@@ -66,7 +66,7 @@
         <div class="main-col">
             <div class="col-inner">
                 <header class="page-header">
-                    <h2 class="header-title">{$Section->Title|escape} <small class="muted">Public Feed</small></h2>
+                    <h2 class="header-title">{$Section->getTitle()|escape} <small class="muted">Public Feed</small></h2>
                     <div class="header-buttons"><a href="{$Section->getURL()}/post" class="button primary">Create a Post</a></div>
                 </header>
 

--- a/php-classes/Slate/Connectors/AbstractSpreadsheetConnector.php
+++ b/php-classes/Slate/Connectors/AbstractSpreadsheetConnector.php
@@ -1647,8 +1647,6 @@ class AbstractSpreadsheetConnector extends \Emergence\Connectors\AbstractSpreads
         $title = null;
         if (!empty($row['Title'])) {
             $title = $row['Title'];
-        } elseif (!$Section->Title) {
-            $title = $Section->Course->Title ?: $Section->Course->Code;
         }
 
         if ($title) {

--- a/php-classes/Slate/Courses/Section.php
+++ b/php-classes/Slate/Courses/Section.php
@@ -264,6 +264,10 @@ class Section extends \VersionedRecord
 
     public function getTitle()
     {
+        if ($this->Title) {
+            return $this->Title;
+        }
+
         $title = $this->Course->Title;
 
         if (count($this->Teachers)) {

--- a/php-classes/Slate/Courses/Section.php
+++ b/php-classes/Slate/Courses/Section.php
@@ -267,6 +267,21 @@ class Section extends \VersionedRecord
         parent::save($deep);
     }
 
+    public function getTitle()
+    {
+        $title = $this->Title;
+
+        if (count($this->Teachers)) {
+            $title .= " / {$this->Teachers[0]->LastName}";
+        }
+
+        if ($this->Schedule) {
+            $title .= " / {$this->Schedule->Title}";
+        }
+
+        return $title;
+    }
+
     public function getHandle()
     {
         return $this->Code;

--- a/php-classes/Slate/Courses/Section.php
+++ b/php-classes/Slate/Courses/Section.php
@@ -272,11 +272,11 @@ class Section extends \VersionedRecord
         $title = $this->Title;
 
         if (count($this->Teachers)) {
-            $title .= " / {$this->Teachers[0]->LastName}";
+            $title .= ", {$this->Teachers[0]->LastName}";
         }
 
         if ($this->Schedule) {
-            $title .= " / {$this->Schedule->Title}";
+            $title .= ", {$this->Schedule->Title}";
         }
 
         return $title;

--- a/php-classes/Slate/Courses/Section.php
+++ b/php-classes/Slate/Courses/Section.php
@@ -272,11 +272,11 @@ class Section extends \VersionedRecord
         $title = $this->Title;
 
         if (count($this->Teachers)) {
-            $title .= ", {$this->Teachers[0]->LastName}";
+            $title .= "\xC2\xA0\xC2\xB7 {$this->Teachers[0]->LastName}";
         }
 
         if ($this->Schedule) {
-            $title .= ", {$this->Schedule->Title}";
+            $title .= "\xC2\xA0\xC2\xB7 {$this->Schedule->Title}";
         }
 
         return $title;

--- a/php-classes/Slate/Courses/Section.php
+++ b/php-classes/Slate/Courses/Section.php
@@ -269,7 +269,7 @@ class Section extends \VersionedRecord
 
     public function getTitle()
     {
-        $title = $this->Title;
+        $title = $this->Course->Title;
 
         if (count($this->Teachers)) {
             $title .= "\xC2\xA0\xC2\xB7 {$this->Teachers[0]->LastName}";

--- a/php-classes/Slate/Courses/Section.php
+++ b/php-classes/Slate/Courses/Section.php
@@ -81,7 +81,7 @@ class Section extends \VersionedRecord
             ,'index' => true
         ]
         ,'Title' => [
-            'notnull' => true
+            'default' => null
         ]
         ,'Code' => [
             'unique' => true
@@ -248,11 +248,6 @@ class Section extends \VersionedRecord
 
     public function save($deep = true)
     {
-        // set title
-        if (!$this->Title) {
-            $this->Title = $this->Course->Title;
-        }
-
         // generate short code
         if (!$this->Code) {
             $this->Code = HandleBehavior::getUniqueHandle(static::class, $this->Course->Code, [

--- a/php-classes/Slate/People/PeopleRequestHandler.php
+++ b/php-classes/Slate/People/PeopleRequestHandler.php
@@ -102,7 +102,7 @@ class PeopleRequestHandler extends \PeopleRequestHandler
                 $lists[] = [
                     'groupId' => 'sections',
                     'groupLabel' => 'My Sections',
-                    'label' => $Section->Code,
+                    'label' => $Section->getTitle(),
                     'value' => "section:{$Section->Code}"
                 ];
 
@@ -110,7 +110,7 @@ class PeopleRequestHandler extends \PeopleRequestHandler
                     $lists[] = [
                         'groupId' => 'sections',
                         'groupLabel' => 'My Sections',
-                        'label' => "{$Section->Code} ▸ {$cohort}",
+                        'label' => "{$Section->getTitle} ▸ {$cohort}",
                         'value' => "section:{$Section->Code}:{$cohort}"
                     ];
                 }

--- a/php-classes/Slate/Progress/AbstractSectionTermReport.php
+++ b/php-classes/Slate/Progress/AbstractSectionTermReport.php
@@ -73,6 +73,6 @@ abstract class AbstractSectionTermReport extends AbstractReport implements IStud
 
     public function getTitle()
     {
-        return sprintf('%s, %s', $this->Section->Title, $this->Term->Title);
+        return sprintf('%s, %s', $this->Section->getTitle(), $this->Term->getTitle());
     }
 }

--- a/php-migrations/Slate/Courses/20201226_section-null-titles.php
+++ b/php-migrations/Slate/Courses/20201226_section-null-titles.php
@@ -1,0 +1,29 @@
+<?php
+
+$tableName = 'course_sections';
+$historyTableName = 'history_course_sections';
+
+
+if (!static::tableExists($tableName)) {
+    printf("Skipping migration because table `%s` doesn't exist yet\n", $tableName);
+    return static::STATUS_SKIPPED;
+}
+
+if (static::getColumnIsNullable($tableName, 'Title')) {
+    printf("Skipping migration because table `%s` already has nullable Title column\n", $tableName);
+    return static::STATUS_SKIPPED;
+}
+
+
+printf("Upgrading %s table\n", $tableName);
+DB::nonQuery('ALTER TABLE `%s` CHANGE  `Title` `Title` varchar(255) NULL default NULL', $tableName);
+
+printf("Upgrading %s table\n", $historyTableName);
+DB::nonQuery('ALTER TABLE `%s` CHANGE  `Title` `Title` varchar(255) NULL default NULL', $historyTableName);
+
+printf("Removing section titles that match course titles\n");
+DB::nonQuery('UPDATE `%s` SET Title = NULL WHERE Title = (SELECT Title FROM courses WHERE ID = CourseID)', $tableName);
+printf("Removed titles from %u sections\n", DB::affectedRows());
+
+
+return static::STATUS_EXECUTED;

--- a/sencha-workspace/packages/slate-core-data/src/model/course/Section.js
+++ b/sencha-workspace/packages/slate-core-data/src/model/course/Section.js
@@ -76,6 +76,12 @@ Ext.define('Slate.model.course.Section', {
             name: 'LocationID',
             type: 'int',
             allowNull: true
+        },
+
+        // virtual fields
+        {
+            name: 'recordTitle',
+            persist: false
         }
     ],
 

--- a/sencha-workspace/packages/slate-core-data/src/proxy/courses/Sections.js
+++ b/sencha-workspace/packages/slate-core-data/src/proxy/courses/Sections.js
@@ -5,6 +5,6 @@ Ext.define('Slate.proxy.courses.Sections', {
 
     config: {
         url: '/sections',
-        include: ['Term']
+        include: ['Term', 'recordTitle']
     }
 });


### PR DESCRIPTION
## Why

School users need more information in lists of sections to separate them

## What

- Implement a dynamic `getTitle()` method for sections that includes additional dynamic details
- Propagate dynamic record title through UI

## TODO

- [x] add override title field (null out existing where it matches course and use that?)
- [x] switch to middot
- [x] test /manage behavior editing sections
- [x] audit slate pages for spots that need to use getTitle/recordTitle