### PR TITLE
feat: improve term/interim email recipient tracking [SCHOOL-42]

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -19,6 +19,30 @@ build-admin() {
     build-app SlateAdmin
 }
 
+STUDIO_HELP['load-fixtures']="Reset database and load fixture data"
+load-fixtures() {
+    echo "Building fixtures from working tree..."
+    pushd "${EMERGENCE_REPO}" > /dev/null
+    fixtures_tree=$(git holo project --working fixtures)
+    popd > /dev/null
+
+    : "${fixtures_tree:?Failed to build fixtures tree}"
+
+    echo "Resetting database"
+    reset-mysql
+
+    echo "Loading fixtures..."
+    (
+        for fixture_file in $(git ls-tree -r --name-only ${fixtures_tree}); do
+            git cat-file -p "${fixtures_tree}:${fixture_file}"
+        done
+    ) | mysql "${DB_DATABASE}"
+
+    echo "Running migrations..."
+    console-run migrations:execute --all
+}
+
+
 
 ## final init and output
 studio-help

--- a/php-classes/Slate/Progress/AbstractSectionTermReportsRequestHandler.php
+++ b/php-classes/Slate/Progress/AbstractSectionTermReportsRequestHandler.php
@@ -159,7 +159,7 @@ abstract class AbstractSectionTermReportsRequestHandler extends \RecordsRequestH
                                 'StudentID' => $Student->ID,
                                 'TermID' => $Term->ID,
                                 'EmailContactID' => $recipientEmail->ID,
-                                'Status' => 'sent'
+                                'Status' => $sent > 0 ? 'sent' : 'failed'
                             ], true);
                         }
                     }

--- a/php-classes/Slate/Progress/SectionInterimReportRecipient.php
+++ b/php-classes/Slate/Progress/SectionInterimReportRecipient.php
@@ -19,7 +19,7 @@ class SectionInterimReportRecipient extends \ActiveRecord
         'EmailContactID' => 'uint',
         'Status' => [
             'type' => 'enum',
-            'values' => ['pending', 'sent', 'bounced'],
+            'values' => ['failed', 'pending', 'sent', 'bounced'],
             'default' => 'pending'
         ]
     ];

--- a/php-classes/Slate/Progress/SectionTermReportRecipient.php
+++ b/php-classes/Slate/Progress/SectionTermReportRecipient.php
@@ -19,7 +19,7 @@ class SectionTermReportRecipient extends \ActiveRecord
         'EmailContactID' => 'uint',
         'Status' => [
             'type' => 'enum',
-            'values' => ['pending', 'sent', 'bounced'],
+            'values' => ['failed', 'pending', 'sent', 'bounced'],
             'default' => 'pending'
         ]
     ];

--- a/php-migrations/Slate/Progress/20201229_failed-recipients.php
+++ b/php-migrations/Slate/Progress/20201229_failed-recipients.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Slate\Progress;
+
+$status = static::STATUS_SKIPPED;
+
+if (
+    static::tableExists(SectionInterimReportRecipient::$tableName)
+    && !static::hasColumnEnumValue(SectionInterimReportRecipient::$tableName, 'Status', 'failed')
+) {
+    printf("Adding 'failed' value to Status column in table %s\n", SectionInterimReportRecipient::$tableName);
+    static::addColumnEnumValue(SectionInterimReportRecipient::$tableName, 'Status', 'failed');
+    $status = static::STATUS_EXECUTED;
+}
+
+if (
+    static::tableExists(SectionTermReportRecipient::$tableName)
+    && !static::hasColumnEnumValue(SectionTermReportRecipient::$tableName, 'Status', 'failed')
+) {
+    printf("Adding 'failed' value to Status column in table %s\n", SectionTermReportRecipient::$tableName);
+    static::addColumnEnumValue(SectionTermReportRecipient::$tableName, 'Status', 'failed');
+    $status = static::STATUS_EXECUTED;
+}
+
+return $status;

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
@@ -147,7 +147,12 @@ Ext.define('SlateAdmin.controller.progress.interims.Email', {
 
         for (; i < emailsCount; i++) {
             email = emailsStore.getAt(i);
-            recipients = email.get('recipients').filter(recipient => recipient.status == 'proposed');
+            recipients = email.get('recipients').filter(
+                recipient =>
+                    recipient.status == 'proposed'
+                    || recipient.status == 'failed'
+                    || recipient.status == 'bounced'
+            );
 
             if (!recipients.length) {
                 continue;

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
@@ -147,7 +147,12 @@ Ext.define('SlateAdmin.controller.progress.terms.Email', {
 
         for (; i < emailsCount; i++) {
             email = emailsStore.getAt(i);
-            recipients = email.get('recipients').filter(recipient => recipient.status == 'proposed');
+            recipients = email.get('recipients').filter(
+                recipient =>
+                    recipient.status == 'proposed'
+                    || recipient.status == 'failed'
+                    || recipient.status == 'bounced'
+            );
 
             if (!recipients.length) {
                 continue;

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Grid.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Grid.js
@@ -45,7 +45,7 @@ Ext.define('SlateAdmin.view.progress.interims.email.Grid', {
             tpl: [
                 '<ul class="recipients-list">',
                 '   <tpl for="recipients">',
-                '       <li class="status-{status}">{name} <span class="recipient-contact">{email}</span> ({relationship})</li>',
+                '       <li class="status-{status}" title="Status: {status}">{name} <span class="recipient-contact">{email}</span> ({relationship})</li>',
                 '   </tpl>',
                 '</ul>'
             ]

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Grid.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Grid.js
@@ -45,7 +45,7 @@ Ext.define('SlateAdmin.view.progress.terms.email.Grid', {
             tpl: [
                 '<ul class="recipients-list">',
                 '   <tpl for="recipients">',
-                '       <li class="status-{status}">{name} <span class="recipient-contact">{email}</span> ({relationship})</li>',
+                '       <li class="status-{status}" title="Status: {status}">{name} <span class="recipient-contact">{email}</span> ({relationship})</li>',
                 '   </tpl>',
                 '</ul>'
             ]

--- a/sencha-workspace/SlateAdmin/sass/src/view/progress/interims/email/Grid.scss
+++ b/sencha-workspace/SlateAdmin/sass/src/view/progress/interims/email/Grid.scss
@@ -11,15 +11,33 @@
         }
 
         &:before {
-            color: lightgrey;
-            content: '\f0c8'; // fa-square
             font-family: FontAwesome;
             margin-right: 0.5em;
+        }
+
+        &.status-proposed:before {
+            color: lightgrey;
+            content: '\f0c8'; // fa-square
+        }
+
+        &.status-pending:before {
+            color: orange;
+            content: '\f254'; // fa-hourglass
         }
 
         &.status-sent:before {
             color: green;
             content: '\f14a'; // fa-check-square
+        }
+
+        &.status-failed:before {
+            color: red;
+            content: '\f057'; // fa-times-circle
+        }
+
+        &.status-bounced:before {
+            color: red;
+            content: '\f04c'; // fa-pause
         }
     }
 


### PR DESCRIPTION
## Why

Term/interim emails that fail to send are not presented in the UI correctly or handleable

## What

- (unrelated) add load-fixtures command to studio
- track in recipient record when email fails to send
- expose recipient status text via hover
- style icons differently for each recipient status
- enable re-sending to failed/bounced recipients

## Screenshots

![image](https://user-images.githubusercontent.com/458494/103446014-c1571c80-4c48-11eb-89fc-ecea21c59980.png)
