### PR TITLE
SCHOOL-31 Surface disabled accounts in people search

### DIFF
--- a/sencha-workspace/SlateAdmin/app/view/Navigation.js
+++ b/sencha-workspace/SlateAdmin/app/view/Navigation.js
@@ -7,7 +7,7 @@ Ext.define('SlateAdmin.view.Navigation', {
 
     cls: 'slateadmin-navigation',
 
-    width: 200,
+    width: 240,
     layout: {
         type: 'accordion'
     },

--- a/sencha-workspace/SlateAdmin/app/view/Navigation.js
+++ b/sencha-workspace/SlateAdmin/app/view/Navigation.js
@@ -1,6 +1,5 @@
-/*jslint browser: true, undef: true *//*global Ext*/
 Ext.define('SlateAdmin.view.Navigation', {
-    extend: 'Ext.Container' ,
+    extend: 'Ext.Container',
     xtype: 'slateadmin-navigation',
     requires: [
         'Ext.layout.container.Accordion'

--- a/sencha-workspace/SlateAdmin/app/view/people/AdvancedSearchForm.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/AdvancedSearchForm.js
@@ -1,4 +1,3 @@
-/*jslint browser: true, undef: true *//*global Ext*/
 /**
  * Advanced Search Form
  */
@@ -84,7 +83,7 @@ Ext.define('SlateAdmin.view.people.AdvancedSearchForm', {
                     { name: 'LastName' },
                     {
                         name: 'FullName',
-                        calculate: function(data) {
+                        calculate: function (data) {
                             return data.LastName + ', ' + data.FirstName;
                         },
                         depends: ['FirstName', 'LastName']
@@ -116,7 +115,7 @@ Ext.define('SlateAdmin.view.people.AdvancedSearchForm', {
                     { name: 'LastName' },
                     {
                         name: 'FullName',
-                        calculate: function(data) {
+                        calculate: function (data) {
                             return data.LastName + ', ' + data.FirstName;
                         },
                         depends: ['FirstName', 'LastName']
@@ -145,7 +144,7 @@ Ext.define('SlateAdmin.view.people.AdvancedSearchForm', {
                 proxy: {
                     type: 'slateapi',
                     summary: true,
-                    url: window.SiteEnvironment && window.SiteEnvironment.user ? ('/people/'+window.SiteEnvironment.user.Username+'/courses') : '/sections',
+                    url: window.SiteEnvironment && window.SiteEnvironment.user ? '/people/' + window.SiteEnvironment.user.Username + '/courses' : '/sections',
                     reader: {
                         type: 'json',
                         rootProperty: 'data'

--- a/sencha-workspace/SlateAdmin/app/view/people/AdvancedSearchForm.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/AdvancedSearchForm.js
@@ -14,8 +14,10 @@ Ext.define('SlateAdmin.view.people.AdvancedSearchForm', {
     layout: 'auto',
     items: [{
         xtype: 'fieldset',
+        border: 0,
         title: 'Advanced Search',
         cls: 'navpanel-search-criteria',
+        id: 'navpanel-search-criteria',
         collapsible: true,
         collapsed: true,
         // stateful: true, TODO fix collapsing state bug
@@ -150,6 +152,20 @@ Ext.define('SlateAdmin.view.people.AdvancedSearchForm', {
                         rootProperty: 'data'
                     }
                 }
+            }
+        }, {
+            xtype: 'combo',
+            name: 'status',
+            fieldLabel: 'Status',
+            displayField: 'label',
+            emptyText: 'Active only',
+            store: {
+                fields: ['label', 'value'],
+                data: [
+                    { label: 'Active only', },
+                    { label: 'Disabled only', },
+                    { label: 'Any' },
+                ]
             }
         }, {
             xtype: 'button',

--- a/sencha-workspace/SlateAdmin/app/view/people/Grid.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/Grid.js
@@ -1,4 +1,3 @@
-/*jslint browser: true, undef: true *//*global Ext*/
 Ext.define('SlateAdmin.view.people.Grid', {
     extend: 'Ext.grid.Panel',
     xtype: 'people-grid',
@@ -9,10 +8,10 @@ Ext.define('SlateAdmin.view.people.Grid', {
 
 
     // people-grid config
-//    exportItems: null,
-//    firstRefill: true,
-//    exportFieldsLoaded: false,
-//    pendingCheckedFields: false,
+    //    exportItems: null,
+    //    firstRefill: true,
+    //    exportFieldsLoaded: false,
+    //    pendingCheckedFields: false,
 
 
     // grid config
@@ -31,60 +30,60 @@ Ext.define('SlateAdmin.view.people.Grid', {
         xtype: 'tbtext',
         itemId: 'selectionCount',
         text: ''
-    },{
+    }, {
         xtype: 'tbfill'
-    },{
+    }, {
         xtype: 'button',
         text: 'Export Results',
         itemId: 'exportResultsBtn',
         glyph: 0xf064,
         menu: {
-//            showSeparator: true,
-            //plain: true,
+            //            showSeparator: true,
+            // plain: true,
             stateId: 'people-grid-exportmenu',
             // TODO: store selected columns in state
-//            stateful: true,
-//            stateEvents: [
-//                'exportformatchange'
-//            ],
-//            getState: function() {
-//                var state = {},
-//                    checkedFields = this.query('#exportFieldsMenu menucheckitem[checked=true]'),
-//                    checkedValues = !Ext.isEmpty(checkedFields) ? Ext.Array.map(checkedFields, function(field) {
-//                        return field.value;
-//                    }) : false;
-//
-//                state.exportType = this.down('#exportTypeMenu menucheckitem[checked=true]').value;
-//                state.exportFields = checkedValues;
-//
-//                return (state.exportFields && state.exportType) ? state : Ext.state.Manager.get('exportResultsMenu');
-//            },
-//            applyState: function(state) {
-//                var me = this;
-//
-//                if(state) {
-//                    if(state.exportType) {
-//                        me.down('#exportTypeMenu menucheckitem[value='+state.exportType+']').setChecked(true);
-//                    }
-//
-//                    if(state.exportFields) {
-//                        if(!me.exportFieldsLoaded) {
-//                            me.pendingCheckedFields = state.exportFields;
-//                        }
-//
-//                        setTimeout(function() {
-//                            me.fireEvent('exportfieldsrefill', (!me.pendingCheckedFields ? state.exportFields: me.pendingCheckedFields));
-//                        }, 1000);
-//                    }
-//                }
-//            },
+            //            stateful: true,
+            //            stateEvents: [
+            //                'exportformatchange'
+            //            ],
+            //            getState: function() {
+            //                var state = {},
+            //                    checkedFields = this.query('#exportFieldsMenu menucheckitem[checked=true]'),
+            //                    checkedValues = !Ext.isEmpty(checkedFields) ? Ext.Array.map(checkedFields, function(field) {
+            //                        return field.value;
+            //                    }) : false;
+            //
+            //                state.exportType = this.down('#exportTypeMenu menucheckitem[checked=true]').value;
+            //                state.exportFields = checkedValues;
+            //
+            //                return (state.exportFields && state.exportType) ? state : Ext.state.Manager.get('exportResultsMenu');
+            //            },
+            //            applyState: function(state) {
+            //                var me = this;
+            //
+            //                if(state) {
+            //                    if(state.exportType) {
+            //                        me.down('#exportTypeMenu menucheckitem[value='+state.exportType+']').setChecked(true);
+            //                    }
+            //
+            //                    if(state.exportFields) {
+            //                        if(!me.exportFieldsLoaded) {
+            //                            me.pendingCheckedFields = state.exportFields;
+            //                        }
+            //
+            //                        setTimeout(function() {
+            //                            me.fireEvent('exportfieldsrefill', (!me.pendingCheckedFields ? state.exportFields: me.pendingCheckedFields));
+            //                        }, 1000);
+            //                    }
+            //                }
+            //            },
             items: [{
                 text: 'JSON',
                 exportFormat: 'json'
-            },{
+            }, {
                 text: 'PDF',
                 exportFormat: 'pdf'
-            },{
+            }, {
                 text: 'CSV',
                 exportFormat: 'csv',
                 menu: {
@@ -106,7 +105,7 @@ Ext.define('SlateAdmin.view.people.Grid', {
             }]
         },
         action: 'export-people'
-    },{
+    }, {
         xtype: 'button',
         itemId: 'sendInvitationsBtn',
         // icon: '/img/icons/fugue/mail--arrow.png',
@@ -122,43 +121,43 @@ Ext.define('SlateAdmin.view.people.Grid', {
             dataIndex: 'PrimaryPhotoID',
             width: 30,
             resizable: false,
-            renderer: function(v, metaData, record) {
-                if(v) {
-                    metaData.style = 'background: url(/thumbnail/'+v+'/30x30/cropped) no-repeat center center; background-size: cover';
+            renderer: function (v, metaData, record) {
+                if (v) {
+                    metaData.style = 'background: url(/thumbnail/' + v + '/30x30/cropped) no-repeat center center; background-size: cover';
                 }
             }
-        },{
+        }, {
             text: 'First Name',
             dataIndex: 'FirstName',
             sortable: true,
             width: 100
-        },{
+        }, {
             text: 'Last Name',
             dataIndex: 'LastName',
             sortable: true,
             width: 100
-        },{
+        }, {
             text: 'Username',
             dataIndex: 'Username',
             flex: 1
-        },{
+        }, {
             text: 'Email',
             dataIndex: 'Email',
             hidden: true,
-            flex:1,
-            renderer: function(v) {
-                return v ? '<a href="mailto:'+v+'">'+v+'</a>' : '';
+            flex: 1,
+            renderer: function (v) {
+                return v ? '<a href="mailto:' + v + '">' + v + '</a>' : '';
             }
-        },{
+        }, {
             text: 'Student #',
             dataIndex: 'StudentNumber',
             width: 100
-        },{
+        }, {
             text: 'Advisor',
             dataIndex: 'Advisor',
             xtype: 'templatecolumn',
             tpl: '<tpl for="Advisor">{LastName}</tpl>'
-        },{
+        }, {
             text: 'Grad. Year',
             dataIndex: 'GraduationYear',
             width: 90
@@ -168,44 +167,44 @@ Ext.define('SlateAdmin.view.people.Grid', {
 
     // people-grid methods
     // TODO: move these to controller
-//    setExportItems: function(exportItems) {
-//        if(!exportItems)
-//            return false;
-//
-//        this.exportItems = exportItems;
-//        this.updateExportItems(exportItems);
-//
-//    },
-//
-//    getExportItems: function() {
-//        return this.exportItems;
-//    },
-//
-//    updateExportItems: function(exportItems) {
-//        var menu = this.down('#exportResultsBtn #exportFieldsMenu'),
-//            checkItemCmps = [], checkItem, i;
-//
-//        menu.removeAll();
-//
-//        for (i = 0;i<exportItems.length; i++) {
-//            checkItem = {xtype: 'menucheckitem', checked: true, value: exportItems[i].columnId};
-//
-//            checkItem.text = exportItems[i].title;
-//
-//            checkItemCmps.push(checkItem);
-//        }
-//
-//        menu.add(checkItemCmps);
-//        this.exportFieldsLoaded = true;
-//    },
-//
-//    checkExportItems: function(exportItems) {
-//        var exportBtn = this.down('#exportResultsBtn'),
-//            checkItems = exportBtn.menu.query('#exportFieldsMenu menucheckitem'),
-//            key;
-//
-//        for(key in checkItems) {
-//            checkItems[key].setChecked(Ext.Array.contains(exportItems, checkItems[key].value), true);
-//        }
-//    }
+    //    setExportItems: function(exportItems) {
+    //        if(!exportItems)
+    //            return false;
+    //
+    //        this.exportItems = exportItems;
+    //        this.updateExportItems(exportItems);
+    //
+    //    },
+    //
+    //    getExportItems: function() {
+    //        return this.exportItems;
+    //    },
+    //
+    //    updateExportItems: function(exportItems) {
+    //        var menu = this.down('#exportResultsBtn #exportFieldsMenu'),
+    //            checkItemCmps = [], checkItem, i;
+    //
+    //        menu.removeAll();
+    //
+    //        for (i = 0;i<exportItems.length; i++) {
+    //            checkItem = {xtype: 'menucheckitem', checked: true, value: exportItems[i].columnId};
+    //
+    //            checkItem.text = exportItems[i].title;
+    //
+    //            checkItemCmps.push(checkItem);
+    //        }
+    //
+    //        menu.add(checkItemCmps);
+    //        this.exportFieldsLoaded = true;
+    //    },
+    //
+    //    checkExportItems: function(exportItems) {
+    //        var exportBtn = this.down('#exportResultsBtn'),
+    //            checkItems = exportBtn.menu.query('#exportFieldsMenu menucheckitem'),
+    //            key;
+    //
+    //        for(key in checkItems) {
+    //            checkItems[key].setChecked(Ext.Array.contains(exportItems, checkItems[key].value), true);
+    //        }
+    //    }
 });

--- a/sencha-workspace/SlateAdmin/app/view/people/Grid.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/Grid.js
@@ -26,6 +26,20 @@ Ext.define('SlateAdmin.view.people.Grid', {
         pruneRemoved: false
     },
 
+    tbar: {
+        cls: 'info-bar',
+        items: [{
+            xtype: 'tbtext',
+            html: '<i class="fa fa-info-circle"></i>&ensp;6 disabled accounts hidden.',
+        }, {
+            xtype: 'button',
+            text: 'Show All',
+        }, {
+            xtype: 'button',
+            text: 'Dismiss',
+        }],
+    },
+
     bbar: [{
         xtype: 'tbtext',
         itemId: 'selectionCount',

--- a/sencha-workspace/SlateAdmin/app/view/people/NavPanel.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/NavPanel.js
@@ -1,4 +1,3 @@
-/*jslint browser: true, undef: true *//*global Ext*/
 /**
  * People Navigation Panel, an extension of Ext Panel with a vbox layout containing the advanced search form and
  * a tree panel, with a formpanel/searchfield docked to top of container.
@@ -27,9 +26,46 @@ Ext.define('SlateAdmin.view.people.NavPanel', {
         xtype: 'form',
         cls: 'navpanel-search-form',
         items: [{
-            xtype: 'jarvus-searchfield',
-            anchor: '100%',
-            emptyText: 'Search all people…'
+            xtype: 'container',
+            layout: {
+                type: 'hbox',
+                align: 'stretch'
+            },
+            items: [{
+                flex: 1,
+                xtype: 'jarvus-searchfield',
+                reference: 'people-search-field',
+                hideTrigger: true,
+                triggers: {
+                    clear: {
+                        cls: 'x-form-clear-trigger',
+                        handler: function () {
+                            this.setValue('');
+                        }
+                    }
+                },
+                emptyText: 'Search all people…',
+                listeners: {
+                    change: function (me, newValue) {
+                        if (newValue.length > 0) {
+                            me.setHideTrigger(false);
+                        } else {
+                            me.setHideTrigger(true);
+                        }
+                    }
+                }
+            }, {
+                width: 36,
+                xtype: 'button',
+                enableToggle: true,
+                glyph: 0xf013, // fa-cog
+                cls: 'navpanel-advanced-search-toggle',
+                ariaLabel: 'Toggle advanced search options',
+                ui: 'plain',
+                toggleHandler: function (me, state) {
+                    Ext.getCmp('navpanel-search-criteria').setCollapsed(!state);
+                }
+            }],
         }]
     }, {
         dock: 'bottom',
@@ -87,9 +123,9 @@ Ext.define('SlateAdmin.view.people.NavPanel', {
             xtype: 'treecolumn',
             flex: 1,
             dataIndex: 'Name'
-//        },{
-//            width: 20,
-//            dataIndex: 'Population'
+            //        },{
+            //            width: 20,
+            //            dataIndex: 'Population'
         }]
     }]
 });

--- a/sencha-workspace/SlateAdmin/sass/etc/all.scss
+++ b/sencha-workspace/SlateAdmin/sass/etc/all.scss
@@ -1,1 +1,9 @@
 $base-color: #1f83b1;
+
+.x-toolbar.info-bar {
+    background-color: #f5eed6;
+
+    .fa {
+        color: #a88400;
+    }
+}

--- a/sencha-workspace/SlateAdmin/sass/src/view/Navigation.scss
+++ b/sencha-workspace/SlateAdmin/sass/src/view/Navigation.scss
@@ -14,6 +14,10 @@
 }
 
 .navpanel-search-criteria {
+    legend {
+        display: none;
+    }
+
     .x-form-item-label {
         text-transform: none;
     }

--- a/sencha-workspace/SlateAdmin/sass/src/view/people/NavPanel.scss
+++ b/sencha-workspace/SlateAdmin/sass/src/view/people/NavPanel.scss
@@ -1,0 +1,27 @@
+.navpanel-advanced-search-toggle {
+    background-color: $form-field-background-color;
+    border-style: $form-field-border-style;
+    border-color: $form-field-border-color;
+    border-width: 0 0 1px 1px;
+
+    &:not(.x-btn-pressed) {
+        color: #aaa;
+    }
+
+    >.x-btn-icon-el-default-medium,
+    >.x-btn-icon-el-default-toolbar-medium {
+        margin: 0;
+    }
+
+    .x-btn-glyph {
+        color: inherit;
+        display: block;
+        transition: transform .5s ease-in-out;
+    }
+
+    &.x-btn-pressed {
+        .x-btn-glyph {
+            transform: rotate(360deg);
+        }
+    }
+}


### PR DESCRIPTION
> Marked as draft because it's UI mockups that shouldn't be merged without wiring

###  Improve search UI

- Add a clear button to main search field
- Widen left sidebar a little
- Use a "cog" button to toggle advanced search fieldset, instead of the easily-ignored collapsible header

<img width="246" alt="Screen Shot 2021-03-17 at 3 28 49 PM" src="https://user-images.githubusercontent.com/1154929/111526805-8f2c6580-8735-11eb-8a62-3d8bb0e5a1bd.png">
<img width="247" alt="Screen Shot 2021-03-17 at 3 16 54 PM" src="https://user-images.githubusercontent.com/1154929/111526252-e3831580-8734-11eb-98e9-6dbbe74a59dc.png">
<img width="248" alt="Screen Shot 2021-03-17 at 3 16 47 PM" src="https://user-images.githubusercontent.com/1154929/111526255-e41bac00-8734-11eb-9a7d-bb98ee96b49f.png">

### Mock up two potential options for showing disabled accounts in search

- An "info bar" that appears docked above search results, showing a count of disabled accounts in the current search, with buttons to reveal them or dismiss the message

<img width="646" alt="Screen Shot 2021-03-17 at 3 16 57 PM" src="https://user-images.githubusercontent.com/1154929/111525874-6f487200-8734-11eb-9af0-f9e14eb7f952.png">

- A field in the advanced search options, defaulting to "Active only"

<img width="263" alt="Screen Shot 2021-03-17 at 3 16 32 PM" src="https://user-images.githubusercontent.com/1154929/111526324-fbf33000-8734-11eb-97b8-4505a9af613a.png">
