### PR TITLE
fix(powertools): only allow access to Administrators

### DIFF
--- a/site-root/powertools/_index.php
+++ b/site-root/powertools/_index.php
@@ -1,3 +1,3 @@
 <?php
 
-Emergence\RequestHandler\IndexRequestHandler::handleIndexRequest('Staff');
+Emergence\RequestHandler\IndexRequestHandler::handleIndexRequest('Administrator');


### PR DESCRIPTION
This updates the site-root/powertools/_index.php so that it it calls the index handler with 'Administrator' specified for the requiredAccountLevel parameter.