### PR TITLE
fix(progress): restore CSV export for term and interim reports

### DIFF
--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
@@ -133,7 +133,7 @@ Ext.define('SlateAdmin.controller.progress.interims.Print', {
             url: '/progress/section-interim-reports',
             params: Ext.apply({
                 include: 'Student.Advisor,Section.Teachers'
-            }, this.buildFilters()),
+            }, this.buildReportParams()),
             callback: function(success, operation, response) {
                 var downloadLink = document.createElement('a'),
                     rows = response.data.data,

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
@@ -133,7 +133,7 @@ Ext.define('SlateAdmin.controller.progress.terms.Print', {
             url: '/progress/section-term-reports',
             params: Ext.apply({
                 include: 'Student.Advisor,Section.Teachers'
-            }, this.buildFilters()),
+            }, this.buildReportParams()),
             callback: function(success, operation, response) {
                 var downloadLink = document.createElement('a'),
                     rows = response.data.data,


### PR DESCRIPTION
This function was changed from buildFilters to buildReportParams but was not updated everywhere it was called.
ref: 58b7589710b9ecb27dcd5a383120061dbcc64c00